### PR TITLE
Fix for the last example in README file

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,7 +196,7 @@ github.emojis(function(err, emojiList, stats, response) {
   if (err) throw err;
   console.log('It took %d seconds', stats.fetchDuration);
   console.log('Status code: %d', response.statusCode);
-  console.log('Returned %d emojis', Object.keys(data).length);
+  console.log('Returned %d emojis', Object.keys(emojiList).length);
 });
 ```
 


### PR DESCRIPTION
# Description

The last example in the README file was referencing `data` which doesn't exist in the scope. I changed it with the correct variable.

Here's the correct example: https://github.com/groupon/gofer/blob/master/examples/github.js#L188-L193