### PR TITLE
Run tests on iojs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: node_js
 node_js:
-    - 0.10
+  - 0.10
+  - iojs
 script: make all

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -121,9 +121,11 @@ void function () {
     if (!isObject(pathParams))
       return uri;
     wrappedPathParams = reduce(pathParams, function (acc, value, tag) {
-      var wrappedTag;
+      var encoded, encodedWrapped, wrappedTag;
+      encoded = encodeURIComponent(value);
       wrappedTag = '{' + tag + '}';
-      acc[wrappedTag] = encodeURIComponent(value);
+      encodedWrapped = '%7B' + tag + '%7D';
+      acc[wrappedTag] = acc[encodedWrapped] = encoded;
       return acc;
     }, {});
     wrappedTags = Object.keys(wrappedPathParams);

--- a/src/helpers.coffee
+++ b/src/helpers.coffee
@@ -91,8 +91,10 @@ replacePathParams = (uri, pathParams) ->
   return uri unless isObject pathParams
 
   wrappedPathParams = reduce pathParams, ((acc, value, tag) ->
+    encoded = encodeURIComponent value
     wrappedTag = "{#{tag}}"
-    acc[wrappedTag] = encodeURIComponent(value)
+    encodedWrapped = "%7B#{tag}%7D"
+    acc[wrappedTag] = acc[encodedWrapped] = encoded
     acc
   ), {}
 

--- a/test/hub/event.test.coffee
+++ b/test/hub/event.test.coffee
@@ -9,7 +9,9 @@ server = app = undefined
 describe 'Events', ->
   before (done) ->
     {server} = serverBuilder()
-    server.listen 89001, done
+    server.listen 0, =>
+      {@port} = server.address()
+      done()
 
   socketQueueSpy = bond()
   errorSpy = bond()
@@ -24,7 +26,7 @@ describe 'Events', ->
       hub.on 'success', successSpy
 
       hub.fetch {
-        uri: "http://localhost:89001"
+        uri: "http://127.0.0.1:#{@port}"
         requestId: 'abcde'
       },
       (err, body, headers) ->
@@ -35,7 +37,7 @@ describe 'Events', ->
       assert.hasType Object, successSpy.calledArgs[successSpy.called-1][0]
       logLine = successSpy.calledArgs[successSpy.called-1][0]
       assert.equal 200, logLine.statusCode
-      assert.equal "http://localhost:89001/", logLine.uri
+      assert.equal "http://127.0.0.1:#{@port}/", logLine.uri
       assert.equal "GET", logLine.method
       assert.equal 'abcde', logLine.requestId
       assert.truthy 'did not define connect duration', logLine.connectDuration
@@ -49,7 +51,7 @@ describe 'Events', ->
       hub.on 'success', successSpy
 
       hub.fetch {
-        uri: "http://localhost:89001"
+        uri: "http://127.0.0.1:#{@port}"
         requestId: 'abcde'
         method: 'post'
       },
@@ -61,7 +63,7 @@ describe 'Events', ->
       assert.equal typeof successSpy.calledArgs[successSpy.called-1][0], 'object'
       logLine = successSpy.calledArgs[successSpy.called-1][0]
       assert.equal 201, logLine.statusCode
-      assert.equal "http://localhost:89001/", logLine.uri
+      assert.equal "http://127.0.0.1:#{@port}/", logLine.uri
       assert.equal "POST", logLine.method
       assert.equal 'abcde', logLine.requestId
       assert.truthy 'did not define connect duration', logLine.connectDuration
@@ -78,7 +80,7 @@ describe 'Events', ->
         hub.on 'failure', failureSpy
 
         hub.fetch {
-          uri: "http://localhost:89001/error"
+          uri: "http://127.0.0.1:#{@port}/error"
           requestId: 'abcde'
         },
         (err, body, headers) ->
@@ -91,7 +93,7 @@ describe 'Events', ->
         assert.equal 500, logLine.statusCode
         assert.equal 200, logLine.minStatusCode
         assert.equal 299, logLine.maxStatusCode
-        assert.equal "http://localhost:89001/error", logLine.uri
+        assert.equal "http://127.0.0.1:#{@port}/error", logLine.uri
         assert.equal "GET", logLine.method
         assert.equal 'abcde', logLine.requestId
         assert.truthy 'did not define connect duration', logLine.connectDuration
@@ -105,7 +107,7 @@ describe 'Events', ->
         hub.on 'failure', failureSpy
 
         hub.fetch {
-          uri: "http://localhost:89001"
+          uri: "http://127.0.0.1:#{@port}"
           qs: {__status: 201}
           requestId: 'abcde'
           minStatusCode: 250
@@ -121,7 +123,7 @@ describe 'Events', ->
         assert.equal 201, logLine.statusCode
         assert.equal 250, logLine.minStatusCode
         assert.equal 499, logLine.maxStatusCode
-        assert.equal "http://localhost:89001/?__status=201", logLine.uri
+        assert.equal "http://127.0.0.1:#{@port}/?__status=201", logLine.uri
         assert.equal "GET", logLine.method
         assert.equal 'abcde', logLine.requestId
         assert.truthy 'did not define connect duration', logLine.connectDuration?

--- a/test/hub/smoke.test.coffee
+++ b/test/hub/smoke.test.coffee
@@ -8,7 +8,9 @@ server = app = undefined
 describe 'Basic Integration Test', ->
   before (done) ->
     {server} = serverBuilder()
-    server.listen 89001, done
+    server.listen 0, =>
+      {@port} = server.address()
+      done()
 
   after (done) ->
     server.close done
@@ -16,7 +18,7 @@ describe 'Basic Integration Test', ->
   describe 'making a request', ->
     it "fires the callback", (done) ->
       hub.fetch {
-        uri: "http://localhost:89001"
+        uri: "http://127.0.0.1:#{@port}"
       },
       (err, body, headers) ->
         assert.falsey err

--- a/test/hub/timeout.test.coffee
+++ b/test/hub/timeout.test.coffee
@@ -6,7 +6,9 @@ server = app = undefined
 describe 'Basic Integration Test', ->
   before (done) ->
     {server} = serverBuilder()
-    server.listen 89001, done
+    server.listen 0, =>
+      {@port} = server.address()
+      done()
 
   after (done) ->
     server.close done
@@ -31,7 +33,7 @@ describe 'Basic Integration Test', ->
 
     it 'does not pass an error when timeout is not exceeded', (done) ->
       hub.fetch {
-        uri: "http://localhost:89001"
+        uri: "http://127.0.0.1:#{@port}"
         qs: {__latency: 10}
         timeout: 20
       }, (err, body, headers) ->
@@ -39,7 +41,7 @@ describe 'Basic Integration Test', ->
 
     it 'passes an error when timeout is exceeded', (done) ->
       hub.fetch {
-        uri: "http://localhost:89001"
+        uri: "http://127.0.0.1:#{@port}"
         qs: {__latency: 30}
         timeout: 20
       }, (err, body, headers) ->
@@ -50,7 +52,7 @@ describe 'Basic Integration Test', ->
 
     it 'does not pass an error when timeout is not exceeded', (done) ->
       hub.fetch {
-        uri: "http://localhost:89001"
+        uri: "http://127.0.0.1:#{@port}"
         qs: {__delay: 10}
         completionTimeout: 20
       }, (err, body, headers) ->
@@ -60,7 +62,7 @@ describe 'Basic Integration Test', ->
 
     it 'passes an error when timeout is exceeded', (done) ->
       hub.fetch {
-        uri: "http://localhost:89001"
+        uri: "http://127.0.0.1:#{@port}"
         qs: {__delay: 30}
         completionTimeout: 20
       }, (err, body, headers) ->
@@ -72,7 +74,7 @@ describe 'Basic Integration Test', ->
 
     it 'does not pass an error when timeout and completion timeouts are not exceeded', (done) ->
       hub.fetch {
-        uri: "http://localhost:89001"
+        uri: "http://127.0.0.1:#{@port}"
         qs: {__latency: 20, __delay: 20}
         timeout: 30
         connectTimeout: 30
@@ -84,7 +86,7 @@ describe 'Basic Integration Test', ->
 
     it 'passes an error when completion is exceeded', (done) ->
       hub.fetch {
-        uri: "http://localhost:89001"
+        uri: "http://127.0.0.1:#{@port}"
         qs: {__delay: 20}
         timeout: 30
         connectTimeout: 30
@@ -107,7 +109,7 @@ describe 'Basic Integration Test', ->
 
     it 'passes an error when timeout is exceeded', (done) ->
       hub.fetch {
-        uri: "http://localhost:89001"
+        uri: "http://127.0.0.1:#{@port}"
         qs: {__latency: 20, __delay: 20}
         timeout: 1
         connectTimeout: 30


### PR DESCRIPTION
* Add `iojs` (latest iojs release) to travis configuration
* Handle the differences in `url.parse` which now encodes `{` and `}` under certain conditions
* Fix the invalid TCP port in the test suite (not sure why that worked in earlier node versions)