### PR TITLE
Exclude lib from adding a license

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "registry": "https://registry.npmjs.org",
     "license": {
       "exclude": [
+        "lib",
         "test"
       ]
     }


### PR DESCRIPTION
Follow-up to #28, since comments are forwarded we'd end up with the license twice otherwise.