### PR TITLE
Make sure to be compatible with older hubs

### DIFF
--- a/lib/gofer.js
+++ b/lib/gofer.js
@@ -31,34 +31,36 @@ LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
 NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-var Gofer, Hub, applyBaseUrl, buildUserAgent, cleanObject, extend, merge, parseDefaults, resolveOptional, _ref,
+var Gofer, Hub, applyBaseUrl, buildUserAgent, cleanObject, extend, isJsonResponse, merge, parseDefaults, resolveOptional, safeParseJSON, _ref, _ref1,
   __bind = function(fn, me){ return function(){ return fn.apply(me, arguments); }; };
+
+extend = require('lodash').extend;
 
 Hub = require('./hub');
 
 _ref = require('./helpers'), resolveOptional = _ref.resolveOptional, parseDefaults = _ref.parseDefaults, applyBaseUrl = _ref.applyBaseUrl, buildUserAgent = _ref.buildUserAgent, merge = _ref.merge, cleanObject = _ref.cleanObject;
 
-extend = require('lodash').extend;
+_ref1 = require('./json'), safeParseJSON = _ref1.safeParseJSON, isJsonResponse = _ref1.isJsonResponse;
 
 Gofer = (function() {
   function Gofer(config, _at_hub) {
-    var _ref1;
+    var _ref2;
     this.hub = _at_hub;
     this.request = __bind(this.request, this);
-    _ref1 = parseDefaults(config, this.serviceName), this.defaults = _ref1.defaults, this.endpointDefaults = _ref1.endpointDefaults;
+    _ref2 = parseDefaults(config, this.serviceName), this.defaults = _ref2.defaults, this.endpointDefaults = _ref2.endpointDefaults;
     if (this.hub == null) {
       this.hub = Hub();
     }
   }
 
   Gofer.prototype["with"] = function(overrides) {
-    var copy, endpointDefaults, endpointName, _ref1;
+    var copy, endpointDefaults, endpointName, _ref2;
     copy = new this.constructor({}, this.hub);
     copy.defaults = merge(this.defaults, overrides);
     copy.endpointDefaults = {};
-    _ref1 = this.endpointDefaults;
-    for (endpointName in _ref1) {
-      endpointDefaults = _ref1[endpointName];
+    _ref2 = this.endpointDefaults;
+    for (endpointName in _ref2) {
+      endpointDefaults = _ref2[endpointName];
       copy.endpointDefaults[endpointName] = merge(endpointDefaults, overrides);
     }
     return copy;
@@ -69,42 +71,42 @@ Gofer = (function() {
   };
 
   Gofer.prototype.request = function(uri, options, cb) {
-    var _ref1;
-    _ref1 = resolveOptional(uri, options, cb), options = _ref1.options, cb = _ref1.cb;
+    var _ref2;
+    _ref2 = resolveOptional(uri, options, cb), options = _ref2.options, cb = _ref2.cb;
     return this._request(options, cb);
   };
 
   Gofer.prototype.put = function(uri, options, cb) {
-    var _ref1;
-    _ref1 = resolveOptional(uri, options, cb), options = _ref1.options, cb = _ref1.cb;
+    var _ref2;
+    _ref2 = resolveOptional(uri, options, cb), options = _ref2.options, cb = _ref2.cb;
     options.method = 'PUT';
     return this._request(options, cb);
   };
 
   Gofer.prototype.del = function(uri, options, cb) {
-    var _ref1;
-    _ref1 = resolveOptional(uri, options, cb), options = _ref1.options, cb = _ref1.cb;
+    var _ref2;
+    _ref2 = resolveOptional(uri, options, cb), options = _ref2.options, cb = _ref2.cb;
     options.method = 'DELETE';
     return this._request(options, cb);
   };
 
   Gofer.prototype.head = function(uri, options, cb) {
-    var _ref1;
-    _ref1 = resolveOptional(uri, options, cb), options = _ref1.options, cb = _ref1.cb;
+    var _ref2;
+    _ref2 = resolveOptional(uri, options, cb), options = _ref2.options, cb = _ref2.cb;
     options.method = 'HEAD';
     return this._request(options, cb);
   };
 
   Gofer.prototype.post = function(uri, options, cb) {
-    var _ref1;
-    _ref1 = resolveOptional(uri, options, cb), options = _ref1.options, cb = _ref1.cb;
+    var _ref2;
+    _ref2 = resolveOptional(uri, options, cb), options = _ref2.options, cb = _ref2.cb;
     options.method = 'POST';
     return this._request(options, cb);
   };
 
   Gofer.prototype.patch = function(uri, options, cb) {
-    var _ref1;
-    _ref1 = resolveOptional(uri, options, cb), options = _ref1.options, cb = _ref1.cb;
+    var _ref2;
+    _ref2 = resolveOptional(uri, options, cb), options = _ref2.options, cb = _ref2.cb;
     options.method = 'PATCH';
     return this._request(options, cb);
   };
@@ -148,8 +150,8 @@ Gofer = (function() {
   Gofer.prototype.requestWithDefaults = function(defaults) {
     return (function(_this) {
       return function(uri, options, cb) {
-        var _ref1;
-        _ref1 = resolveOptional(uri, options, cb), options = _ref1.options, cb = _ref1.cb;
+        var _ref2;
+        _ref2 = resolveOptional(uri, options, cb), options = _ref2.options, cb = _ref2.cb;
         options = merge(defaults, options);
         return _this._request(options, cb);
       };
@@ -176,10 +178,10 @@ Gofer = (function() {
   };
 
   Gofer.prototype._request = function(options, cb) {
-    var defaults, err, _base, _ref1;
+    var defaults, err, _base, _ref2;
     defaults = this._getDefaults(this.defaults, options);
     if (options.methodName == null) {
-      options.methodName = ((_ref1 = options.method) != null ? _ref1 : 'get').toLowerCase();
+      options.methodName = ((_ref2 = options.method) != null ? _ref2 : 'get').toLowerCase();
     }
     if (this.serviceName != null) {
       options.serviceName = this.serviceName;
@@ -215,8 +217,13 @@ Gofer = (function() {
       pathParams: options.pathParams
     });
     if (typeof cb === 'function') {
-      return this.hub.fetch(options, function(err, body, response, responseData) {
-        return cb(err, body, responseData, response);
+      return this.hub.fetch(options, function(error, body, response, responseData) {
+        var parseJSON, _ref3, _ref4;
+        parseJSON = (_ref3 = options.parseJSON) != null ? _ref3 : isJsonResponse(response, body);
+        if (parseJSON) {
+          _ref4 = safeParseJSON(body, response), error = _ref4.error, body = _ref4.body;
+        }
+        return cb(error, body, responseData, response);
       });
     } else {
       return this.hub.fetch(options);

--- a/lib/hub.js
+++ b/lib/hub.js
@@ -89,7 +89,7 @@ module.exports = Hub = function() {
       var apiError, logLine, maxStatusCode, minStatusCode, parseJSON, successfulRequest, uri, _ref3, _ref4, _ref5;
       parseJSON = (_ref3 = options.parseJSON) != null ? _ref3 : isJsonResponse(response, body);
       if (parseJSON) {
-        _ref4 = safeParseJSON(body), error = _ref4.error, body = _ref4.result;
+        _ref4 = safeParseJSON(body, response), error = _ref4.error, body = _ref4.body;
       }
       responseData.fetchDuration = getSeconds();
       responseData.requestOptions.uri = this.uri;

--- a/lib/json.js
+++ b/lib/json.js
@@ -31,26 +31,29 @@ LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
 NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-var jsonHeader, nonEmpty;
+var GOFER_PARSED, jsonHeader, nonEmpty;
 
-this.safeParseJSON = function(str) {
+GOFER_PARSED = 'GOFER_PARSED_RESPONSE';
+
+this.safeParseJSON = function(str, res) {
   var data, err;
+  res[GOFER_PARSED] = true;
   data = {
     error: null
   };
   try {
-    data.result = 'string' === typeof str ? JSON.parse(str) : str != null ? str : '';
+    data.body = 'string' === typeof str ? JSON.parse(str) : str != null ? str : '';
   } catch (_error) {
     err = _error;
     data.error = err;
-    data.result = str;
+    data.body = str;
   }
   return data;
 };
 
 jsonHeader = function(res) {
-  var contentType, _ref;
-  contentType = res != null ? (_ref = res.headers) != null ? _ref['content-type'] : void 0 : void 0;
+  var contentType;
+  contentType = res.headers['content-type'];
   if (contentType == null) {
     return false;
   }
@@ -62,5 +65,11 @@ nonEmpty = function(body) {
 };
 
 this.isJsonResponse = function(res, body) {
+  if (!(res != null ? res.headers : void 0)) {
+    return false;
+  }
+  if (res[GOFER_PARSED]) {
+    return false;
+  }
   return jsonHeader(res) && nonEmpty(body);
 };

--- a/src/gofer.coffee
+++ b/src/gofer.coffee
@@ -30,6 +30,8 @@ NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ###
 
+{extend} = require 'lodash'
+
 Hub = require './hub'
 {
   resolveOptional,
@@ -39,7 +41,7 @@ Hub = require './hub'
   merge,
   cleanObject
 } = require './helpers'
-{extend} = require 'lodash'
+{ safeParseJSON, isJsonResponse } = require './json'
 
 class Gofer
   constructor: (config, @hub) ->
@@ -170,9 +172,11 @@ class Gofer
     })
 
     if typeof cb == 'function'
-      @hub.fetch options, (err, body, response, responseData) ->
+      @hub.fetch options, (error, body, response, responseData) ->
+        parseJSON = options.parseJSON ? isJsonResponse(response, body)
+        {error, body} = safeParseJSON body, response if parseJSON
         # TODO: remove flipping of response and responseData with next major
-        cb err, body, responseData, response
+        cb error, body, responseData, response
     else
       @hub.fetch options
 

--- a/src/hub.coffee
+++ b/src/hub.coffee
@@ -80,7 +80,7 @@ module.exports = Hub = ->
 
     handleResult = (error, response, body) ->
       parseJSON = options.parseJSON ? isJsonResponse(response, body)
-      {error, result: body} = safeParseJSON body if parseJSON
+      {error, body} = safeParseJSON body, response if parseJSON
 
       responseData.fetchDuration = getSeconds()
 

--- a/src/json.coffee
+++ b/src/json.coffee
@@ -30,21 +30,25 @@ NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ###
 
-@safeParseJSON = (str) ->
+GOFER_PARSED = 'GOFER_PARSED_RESPONSE'
+
+@safeParseJSON = (str, res) ->
+  res[GOFER_PARSED] = true
+
   data = error: null
   try
-    data.result =
+    data.body =
       if 'string' == typeof str
         JSON.parse str
       else
         str ? ''
   catch err
     data.error  = err
-    data.result = str
+    data.body = str
   data
 
 jsonHeader = (res) ->
-  contentType = res?.headers?['content-type']
+  contentType = res.headers['content-type']
   return false unless contentType?
   contentType.indexOf('application/json') == 0
 
@@ -52,4 +56,6 @@ nonEmpty = (body) ->
   body?.length > 0
 
 @isJsonResponse = (res, body) ->
+  return false unless res?.headers
+  return false if res[GOFER_PARSED]
   jsonHeader(res) && nonEmpty(body)


### PR DESCRIPTION
In 2.3.0 we moved response parsing from `gofer._request` to `hub.fetch`. If an app uses a `gofer/hub` from `gofer@<2.3.0` with a client based on `gofer@>=2.3.0`, the response body will no longer be parsed. It won't hit the previous parsing in `gofer._request` but it won't hit the new parsing in `hub.fetch` either.

With this change we do the parsing in both places, trying to remember that we already parsed if possible. In 3.0.0 we can remove both the switching of argument order and the "try parsing twice" hack.