### PR TITLE
Preserve errors for error responses

### DIFF
--- a/lib/gofer.js
+++ b/lib/gofer.js
@@ -218,10 +218,13 @@ Gofer = (function() {
     });
     if (typeof cb === 'function') {
       return this.hub.fetch(options, function(error, body, response, responseData) {
-        var parseJSON, _ref3, _ref4;
+        var parseError, parseJSON, _ref3, _ref4;
         parseJSON = (_ref3 = options.parseJSON) != null ? _ref3 : isJsonResponse(response, body);
         if (parseJSON) {
-          _ref4 = safeParseJSON(body, response), error = _ref4.error, body = _ref4.body;
+          _ref4 = safeParseJSON(body, response), parseError = _ref4.parseError, body = _ref4.body;
+        }
+        if (error == null) {
+          error = parseError;
         }
         return cb(error, body, responseData, response);
       });

--- a/lib/hub.js
+++ b/lib/hub.js
@@ -94,10 +94,13 @@ module.exports = Hub = function() {
     }, options.logData);
     hub.emit('start', extend(baseLog, responseData));
     handleResult = function(error, response, body) {
-      var apiError, logLine, maxStatusCode, minStatusCode, parseJSON, successfulRequest, uri, _ref5, _ref6, _ref7;
+      var apiError, logLine, maxStatusCode, minStatusCode, parseError, parseJSON, successfulRequest, uri, _ref5, _ref6, _ref7;
       parseJSON = (_ref5 = options.parseJSON) != null ? _ref5 : isJsonResponse(response, body);
       if (parseJSON) {
-        _ref6 = safeParseJSON(body, response), error = _ref6.error, body = _ref6.body;
+        _ref6 = safeParseJSON(body, response), parseError = _ref6.parseError, body = _ref6.body;
+      }
+      if (error == null) {
+        error = parseError;
       }
       responseData.fetchDuration = getSeconds();
       responseData.requestOptions.uri = this.uri;

--- a/src/gofer.coffee
+++ b/src/gofer.coffee
@@ -174,7 +174,8 @@ class Gofer
     if typeof cb == 'function'
       @hub.fetch options, (error, body, response, responseData) ->
         parseJSON = options.parseJSON ? isJsonResponse(response, body)
-        {error, body} = safeParseJSON body, response if parseJSON
+        {parseError, body} = safeParseJSON body, response if parseJSON
+        error ?= parseError
         # TODO: remove flipping of response and responseData with next major
         cb error, body, responseData, response
     else

--- a/src/hub.coffee
+++ b/src/hub.coffee
@@ -92,7 +92,8 @@ module.exports = Hub = ->
 
     handleResult = (error, response, body) ->
       parseJSON = options.parseJSON ? isJsonResponse(response, body)
-      {error, body} = safeParseJSON body, response if parseJSON
+      {parseError, body} = safeParseJSON body, response if parseJSON
+      error ?= parseError
 
       responseData.fetchDuration = getSeconds()
 


### PR DESCRIPTION
Refactoring the JSON parsing accidentally broke `apiError`s when
combining older versions of the hub with `gofer@>=2.3.0`.

This change always preserves the original error and only overrides
it if it was `null`/`undefined`.

Fixes https://github.com/groupon/gofer/issues/34