### PR TITLE
Don't send result immediately in case request is an erroneous synchronous call

### DIFF
--- a/lib/hub.js
+++ b/lib/hub.js
@@ -121,7 +121,10 @@ module.exports = Hub = function() {
         logLine.statusCode = error.code;
         debug('<- %s', error.code, uri);
         hub.emit('fetchError', logLine);
-        return sendResult(error, body);
+        process.nextTick(function() {
+          return sendResult(error, body);
+        });
+        return;
       }
       apiError = null;
       minStatusCode = options.minStatusCode || 200;

--- a/src/hub.coffee
+++ b/src/hub.coffee
@@ -120,7 +120,8 @@ module.exports = Hub = ->
         logLine.statusCode = error.code
         debug '<- %s', error.code, uri
         hub.emit 'fetchError', logLine
-        return sendResult error, body
+        process.nextTick -> sendResult error, body
+        return
 
       apiError = null
       minStatusCode = options.minStatusCode or 200

--- a/test/hub/invalid-url.test.coffee
+++ b/test/hub/invalid-url.test.coffee
@@ -1,0 +1,8 @@
+assert = require 'assertive'
+hub = require('../../hub')()
+
+describe 'Invalid URLs', ->
+  it 'error out with sensible error message', (done) ->
+    hub.fetch uri: "some-invalid/url", (err, body, headers) ->
+      assert.equal 'Invalid protocol: null', err.message
+      done()


### PR DESCRIPTION
If the URL isn't specified correctly (e.g. missing protocol / hostname), then `request` returns immediately, making `req = request options, handleResult` a synchronous call, which can a problem as `req` is used in `sendResult` which is used by `handleResult`.