### PR TITLE
Never pass baseUrl to request

### DIFF
--- a/lib/gofer.js
+++ b/lib/gofer.js
@@ -216,6 +216,9 @@ Gofer = (function() {
       methodName: options.methodName,
       pathParams: options.pathParams
     });
+    if (options.baseUrl) {
+      delete options.baseUrl;
+    }
     if (typeof cb === 'function') {
       return this.hub.fetch(options, function(error, body, response, responseData) {
         var parseError, parseJSON, _ref3, _ref4;

--- a/src/gofer.coffee
+++ b/src/gofer.coffee
@@ -171,6 +171,11 @@ class Gofer
       pathParams: options.pathParams
     })
 
+    # In case an option mapper didn't clean up after itself.
+    # In a future version we should investigate offically switching
+    # to request's baseUrl option.
+    delete options.baseUrl if options.baseUrl
+
     if typeof cb == 'function'
       @hub.fetch options, (error, body, response, responseData) ->
         parseJSON = options.parseJSON ? isJsonResponse(response, body)

--- a/test/request.test.coffee
+++ b/test/request.test.coffee
@@ -155,3 +155,20 @@ describe 'actually making a request', ->
       done()
 
     req.headers['x-sneaky'] = 'sneaky header'
+
+  it 'is not bothered by a weird baseUrl option', (done) ->
+    options =
+      uri: '/zapp'
+      baseUrl:
+        real: defaultConfig.myApi.baseUrl
+        fake: 'http://invalid.url'
+
+    myApi.clearOptionMappers()
+    myApi.addOptionMapper (opts) ->
+      # oops, forgot to delete opts.baseUrl
+      @applyBaseUrl opts.baseUrl.real, opts
+
+    req = myApi.fetch options, (err, reqMirror) ->
+      assert.equal undefined, err?.stack
+      assert.equal '/v1/zapp', reqMirror.url
+      done()


### PR DESCRIPTION
This fixes a regression caused by #41 where an options object containing a `baseUrl` property with an object in it was previously ignored and now causes the request to fail.