### PR TITLE
Force form encoding

### DIFF
--- a/lib/gofer.js
+++ b/lib/gofer.js
@@ -31,7 +31,7 @@ LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
 NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-var Gofer, Hub, applyBaseUrl, buildUserAgent, cleanObject, extend, isJsonResponse, merge, parseDefaults, resolveOptional, safeParseJSON, _ref, _ref1,
+var GOOD_FORM_ENCODED, Gofer, Hub, applyBaseUrl, buildUserAgent, cleanObject, extend, isJsonResponse, merge, parseDefaults, resolveOptional, safeParseJSON, _ref, _ref1,
   __bind = function(fn, me){ return function(){ return fn.apply(me, arguments); }; };
 
 extend = require('lodash').extend;
@@ -41,6 +41,8 @@ Hub = require('./hub');
 _ref = require('./helpers'), resolveOptional = _ref.resolveOptional, parseDefaults = _ref.parseDefaults, applyBaseUrl = _ref.applyBaseUrl, buildUserAgent = _ref.buildUserAgent, merge = _ref.merge, cleanObject = _ref.cleanObject;
 
 _ref1 = require('./json'), safeParseJSON = _ref1.safeParseJSON, isJsonResponse = _ref1.isJsonResponse;
+
+GOOD_FORM_ENCODED = 'application/x-www-form-urlencoded; charset=utf-8';
 
 Gofer = (function() {
   function Gofer(config, _at_hub) {
@@ -178,7 +180,7 @@ Gofer = (function() {
   };
 
   Gofer.prototype._request = function(options, cb) {
-    var defaults, err, _base, _ref2;
+    var defaults, err, form, req, _base, _ref2;
     defaults = this._getDefaults(this.defaults, options);
     if (options.methodName == null) {
       options.methodName = ((_ref2 = options.method) != null ? _ref2 : 'get').toLowerCase();
@@ -219,8 +221,10 @@ Gofer = (function() {
     if (options.baseUrl) {
       delete options.baseUrl;
     }
+    form = options.form;
+    delete options.form;
     if (typeof cb === 'function') {
-      return this.hub.fetch(options, function(error, body, response, responseData) {
+      req = this.hub.fetch(options, function(error, body, response, responseData) {
         var parseError, parseJSON, _ref3, _ref4;
         parseJSON = (_ref3 = options.parseJSON) != null ? _ref3 : isJsonResponse(response, body);
         if (parseJSON) {
@@ -232,8 +236,15 @@ Gofer = (function() {
         return cb(error, body, responseData, response);
       });
     } else {
-      return this.hub.fetch(options);
+      req = this.hub.fetch(options);
     }
+    if (form != null) {
+      req.form(form);
+      if (options.forceFormEncoding !== false) {
+        req.setHeader('Content-Type', GOOD_FORM_ENCODED);
+      }
+    }
+    return req;
   };
 
   Gofer.prototype._mappers = [


### PR DESCRIPTION
This counteracts a regression in request (see https://github.com/request/request/issues/1644).

The request behavior can be enabled by setting `forceFormEncoding` to false explicitly. By default this restores the behavior of `2.3.x`.