### PR TITLE
Keep form.options in options b/c request

### DIFF
--- a/lib/gofer.js
+++ b/lib/gofer.js
@@ -180,7 +180,7 @@ Gofer = (function() {
   };
 
   Gofer.prototype._request = function(options, cb) {
-    var defaults, err, form, req, _base, _ref2;
+    var defaults, err, req, _base, _ref2;
     defaults = this._getDefaults(this.defaults, options);
     if (options.methodName == null) {
       options.methodName = ((_ref2 = options.method) != null ? _ref2 : 'get').toLowerCase();
@@ -221,8 +221,6 @@ Gofer = (function() {
     if (options.baseUrl) {
       delete options.baseUrl;
     }
-    form = options.form;
-    delete options.form;
     if (typeof cb === 'function') {
       req = this.hub.fetch(options, function(error, body, response, responseData) {
         var parseError, parseJSON, _ref3, _ref4;
@@ -238,11 +236,8 @@ Gofer = (function() {
     } else {
       req = this.hub.fetch(options);
     }
-    if (form != null) {
-      req.form(form);
-      if (options.forceFormEncoding !== false) {
-        req.setHeader('Content-Type', GOOD_FORM_ENCODED);
-      }
+    if (options.form && options.forceFormEncoding !== false) {
+      req.setHeader('Content-Type', GOOD_FORM_ENCODED);
     }
     return req;
   };

--- a/test/request.test.coffee
+++ b/test/request.test.coffee
@@ -1,7 +1,7 @@
 assert = require 'assertive'
 http = require 'http'
 Url = require 'url'
-qs = require 'querystring'
+{parse: parseQS} = require 'querystring'
 
 Gofer = require '..'
 
@@ -134,7 +134,7 @@ describe 'actually making a request', ->
       assert.equal '{some-invalid-json}', reqMirror
       done()
 
-  describe.only 'special characters', ->
+  describe 'special characters', ->
     it 'are supported in form payloads', (done) ->
       req = myApi.fetch {
         uri: '/zapp'
@@ -142,7 +142,7 @@ describe 'actually making a request', ->
         form: { x: '💩' }
       }, (err, reqMirror) ->
         return done(err) if err?
-        body = qs.parse reqMirror.body
+        body = parseQS reqMirror.body
         assert.equal '💩', body.x
         assert.equal '''
           application/x-www-form-urlencoded; charset=utf-8
@@ -157,7 +157,7 @@ describe 'actually making a request', ->
         form: { x: '💩' }
       }, (err, reqMirror) ->
         return done(err) if err?
-        body = qs.parse reqMirror.body
+        body = parseQS reqMirror.body
         assert.equal '💩', body.x
         assert.equal '''
           application/x-www-form-urlencoded


### PR DESCRIPTION
The current solution messed with *something* which lead to some services thinking the request body was empty. `<table-flip.gif />`