### PR TITLE
Consistent and safe err.responseData

### DIFF
--- a/lib/hub.js
+++ b/lib/hub.js
@@ -82,11 +82,12 @@ module.exports = Hub = function() {
     extend(options.headers, hubHeaders);
     logPendingRequests(http.globalAgent);
     logPendingRequests(https.globalAgent);
-    responseData = {
-      requestOptions: options,
+    responseData = Object.defineProperty({
       requestId: options.requestId,
       fetchId: fetchId
-    };
+    }, 'requestOptions', {
+      value: options
+    });
     debug('-> %s', options.method, options.uri);
     baseLog = extend({
       uri: options.uri,
@@ -103,8 +104,8 @@ module.exports = Hub = function() {
         error = parseError;
       }
       responseData.fetchDuration = getSeconds();
-      responseData.requestOptions.uri = this.uri;
-      uri = formatUri(responseData.requestOptions.uri);
+      options.uri = this.uri;
+      uri = formatUri(options.uri);
       logLine = extend({
         statusCode: response != null ? response.statusCode : void 0,
         uri: uri,
@@ -121,6 +122,9 @@ module.exports = Hub = function() {
         logLine.statusCode = error.code;
         debug('<- %s', error.code, uri);
         hub.emit('fetchError', logLine);
+        if (error.responseData == null) {
+          error.responseData = responseData;
+        }
         process.nextTick(function() {
           return sendResult(error, body);
         });
@@ -141,6 +145,9 @@ module.exports = Hub = function() {
         apiError.statusCode = response.statusCode;
         apiError.minStatusCode = logLine.minStatusCode = minStatusCode;
         apiError.maxStatusCode = logLine.maxStatusCode = maxStatusCode;
+        if (apiError.responseData == null) {
+          apiError.responseData = responseData;
+        }
         debug('<- %s', response.statusCode, uri);
         hub.emit('failure', logLine);
       }

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "request": "2.57.0"
   },
   "devDependencies": {
-    "assertive": "^1.4.0",
+    "assertive": "^2.0.0",
     "bondjs": "^1.1.1",
     "coffee-script": "1.9.0",
     "deepmerge": "^0.2.7",

--- a/test/proxy.test.coffee
+++ b/test/proxy.test.coffee
@@ -31,7 +31,7 @@ describe 'proxy', ->
     proxy client, req, res, next
 
   it 'makes a request with the client', ->
-    assert.expect requestArgs.length
+    assert.expect requestArgs.length >= 1
 
   it 'uses the correct parameters', ->
     expectedRequestArgs =


### PR DESCRIPTION
* Upgrade to latest assertive
* Make `responseData.requestOptions` not enumerable because it's bound to not be nicely serializable or contain secrets
* All errors should contain `err.responseData` now