### PR TITLE
Make defaults handling class property friendly

### DIFF
--- a/lib/gofer.js
+++ b/lib/gofer.js
@@ -46,14 +46,20 @@ GOOD_FORM_ENCODED = 'application/x-www-form-urlencoded; charset=utf-8';
 
 Gofer = (function() {
   function Gofer(config, _at_hub) {
-    var _ref2;
     this.hub = _at_hub;
     this.request = __bind(this.request, this);
-    _ref2 = parseDefaults(config, this.serviceName), this.defaults = _ref2.defaults, this.endpointDefaults = _ref2.endpointDefaults;
+    this._rawConfig = config;
+    this._defaults = this._endpointDefaults = null;
     if (this.hub == null) {
       this.hub = Hub();
     }
   }
+
+  Gofer.prototype._initDefaults = function() {
+    var _ref2;
+    _ref2 = parseDefaults(this._rawConfig, this.serviceName), this._defaults = _ref2.defaults, this._endpointDefaults = _ref2.endpointDefaults;
+    return this._rawConfig = null;
+  };
 
   Gofer.prototype["with"] = function(overrides) {
     var copy, endpointDefaults, endpointName, _ref2;
@@ -262,6 +268,33 @@ Gofer = (function() {
 Gofer.prototype.fetch = Gofer.prototype.request;
 
 Gofer.prototype.get = Gofer.prototype.request;
+
+Object.defineProperties(Gofer.prototype, {
+  defaults: {
+    enumerable: true,
+    get: function() {
+      if (!this._defaults) {
+        this._initDefaults();
+      }
+      return this._defaults;
+    },
+    set: function(defaults) {
+      return this._defaults = defaults;
+    }
+  },
+  endpointDefaults: {
+    enumerable: true,
+    get: function() {
+      if (!this._endpointDefaults) {
+        this._initDefaults();
+      }
+      return this._endpointDefaults;
+    },
+    set: function(endpointDefaults) {
+      return this._endpointDefaults = endpointDefaults;
+    }
+  }
+});
 
 module.exports = Gofer;
 

--- a/src/gofer.coffee
+++ b/src/gofer.coffee
@@ -47,8 +47,16 @@ GOOD_FORM_ENCODED = 'application/x-www-form-urlencoded; charset=utf-8'
 
 class Gofer
   constructor: (config, @hub) ->
-    { @defaults, @endpointDefaults } = parseDefaults config, @serviceName
+    @_rawConfig = config
+    @_defaults = @_endpointDefaults = null
     @hub ?= Hub()
+
+  _initDefaults: ->
+    {
+      defaults: @_defaults
+      endpointDefaults: @_endpointDefaults
+    } = parseDefaults @_rawConfig, @serviceName
+    @_rawConfig = null
 
   with: (overrides) ->
     copy = new @constructor({}, @hub)
@@ -212,6 +220,24 @@ class Gofer
 
 Gofer::fetch = Gofer::request
 Gofer::get = Gofer::request
+
+Object.defineProperties Gofer.prototype, {
+  defaults:
+    enumerable: true
+    get: ->
+      @_initDefaults() unless @_defaults
+      @_defaults
+    set: (defaults) ->
+      @_defaults = defaults
+
+  endpointDefaults:
+    enumerable: true
+    get: ->
+      @_initDefaults() unless @_endpointDefaults
+      @_endpointDefaults
+    set: (endpointDefaults) ->
+      @_endpointDefaults = endpointDefaults
+}
 
 module.exports = Gofer
 Gofer['default'] = Gofer # ES6 module compatible

--- a/test/delayed_service_name.test.coffee
+++ b/test/delayed_service_name.test.coffee
@@ -1,0 +1,28 @@
+'use strict'
+
+assert = require 'assertive'
+
+Gofer = require '../'
+
+describe 'Delayed serviceName handling', ->
+  # Simulates the following ES proposal:
+  #   https://gist.github.com/jeffmo/054df782c05639da2adb
+  #
+  # ```
+  # class ClassPropStyle extends Gofer {
+  #   serviceName = 'classPropStyle';
+  # }
+  # ```
+  #
+  # Keepin' on being forward-compatible.
+  class ClassPropStyle extends Gofer
+    constructor: (options, hub) ->
+      super options, hub
+      @serviceName = 'classPropStyle'
+
+  it 'extracts the right defaults', ->
+    client = new ClassPropStyle {
+      classPropStyle:
+        baseUrl: 'http://foo.bar:8080'
+    }
+    assert.equal 'http://foo.bar:8080', client.defaults.baseUrl


### PR DESCRIPTION
There's an open ECMAScript proposal to add [class properties](https://gist.github.com/jeffmo/054df782c05639da2adb). With that syntax it's possible to turn this:

```js
class Client extends Gofer {}
Client.prototype.serviceName = 'xyz';
```

Or this:

```js
class Client extends Gofer {
  get serviceName() { return 'xyz'; }
}
```

Into this:

```js
class Client extends Gofer {
  serviceName = 'xyz';
}
```

The problem is that the property initialization has to happen after `this` is available. Which in the case of ECMAScript classes means "super() was called". So if we want to allow the above syntax, we may not use `serviceName` inside of the constructor.

The solution here is to delay calculating the defaults until first use. By providing properties for `client.defaults`, this should not break the interface.