### PR TITLE
Support using decorators to define endpoints

### DIFF
--- a/lib/gofer.js
+++ b/lib/gofer.js
@@ -31,7 +31,7 @@ LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
 NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-var GOOD_FORM_ENCODED, Gofer, Hub, applyBaseUrl, buildUserAgent, cleanObject, extend, isJsonResponse, merge, parseDefaults, resolveOptional, safeParseJSON, _ref, _ref1,
+var Endpoint, GOOD_FORM_ENCODED, Gofer, Hub, applyBaseUrl, buildUserAgent, cleanObject, extend, isJsonResponse, merge, parseDefaults, resolveOptional, safeParseJSON, _ref, _ref1,
   __bind = function(fn, me){ return function(){ return fn.apply(me, arguments); }; };
 
 extend = require('lodash').extend;
@@ -262,6 +262,34 @@ Gofer = (function() {
 Gofer.prototype.fetch = Gofer.prototype.request;
 
 Gofer.prototype.get = Gofer.prototype.request;
+
+Gofer.Endpoint = Endpoint = function(obj, endpointName, _arg) {
+  var innerFn;
+  innerFn = _arg.value;
+  if (typeof innerFn !== 'function') {
+    throw new TypeError('@Endpoint expects a function property');
+  }
+  return {
+    enumerable: false,
+    configurable: true,
+    writeable: true,
+    get: function() {
+      var request, value;
+      if (obj === this) {
+        return innerFn;
+      }
+      request = this.requestWithDefaults({
+        endpointName: endpointName
+      });
+      value = innerFn.bind(this, request);
+      Object.defineProperty(this, endpointName, {
+        enumerable: false,
+        value: value
+      });
+      return value;
+    }
+  };
+};
 
 module.exports = Gofer;
 

--- a/src/gofer.coffee
+++ b/src/gofer.coffee
@@ -213,5 +213,22 @@ class Gofer
 Gofer::fetch = Gofer::request
 Gofer::get = Gofer::request
 
+Gofer.Endpoint = Endpoint = (obj, endpointName, { value: innerFn }) ->
+  if typeof innerFn != 'function'
+    throw new TypeError '@Endpoint expects a function property'
+
+  enumerable: false
+  configurable: true
+  writeable: true
+  get: ->
+    return innerFn if obj == this
+    request = @requestWithDefaults { endpointName }
+    value = innerFn.bind this, request
+    Object.defineProperty this, endpointName, {
+      enumerable: false
+      value
+    }
+    value
+
 module.exports = Gofer
 Gofer['default'] = Gofer # ES6 module compatible

--- a/test/decorator.test.coffee
+++ b/test/decorator.test.coffee
@@ -1,0 +1,77 @@
+'use strict'
+http = require 'http'
+Url = require 'url'
+
+assert = require 'assertive'
+
+Gofer = require '..'
+
+unexpected = ->
+  throw new Error 'Unexpected success'
+
+describe 'promiseHelpers', ->
+  myApi = null
+  server = null
+
+  defaultConfig =
+    globalDefaults:
+      appName: 'myApp'
+      appSha: 'mySha'
+    myApi:
+      endpointDefaults:
+        getThing:
+          qs: { a: 13 }
+
+  before (done) ->
+    server = http.createServer ({url, method, headers}, res) ->
+      if Url.parse(url).pathname == '/v1/zapp'
+        res.writeHead 200, 'Content-Type': 'application/json'
+        res.end JSON.stringify {url, method, headers}
+      else
+        res.writeHead 404, 'Content-Type': 'application/json'
+        res.end JSON.stringify { message: 'not found' }
+
+    server.listen 0, ->
+      {port} = @address()
+      defaultConfig.myApi.baseUrl = "http://127.0.0.1:#{port}/v1"
+      done()
+
+  after (done) ->
+    if server?
+      try server.close()
+    done()
+
+  beforeEach ->
+    # This is the desugared version of something like this:
+    #
+    # ```js
+    # class MyApi extends Gofer {
+    #   serviceName = 'myApi';
+    #   serviceVersion = 'myApi';
+    #
+    #   @Gofer.Endpoint
+    #   getThing(request, kind) {
+    #     return request(`/v1/${kind}`);
+    #   }
+    # }
+    # ```
+    #
+    # See: https://github.com/wycats/javascript-decorators
+    class MyApi extends Gofer
+      serviceName: 'myApi'
+      serviceVersion: '1.0.0'
+
+    propertyDescriptor = Gofer.Endpoint MyApi.prototype, 'getThing', {
+      value: (request, kind) ->
+        request "/#{kind}"
+    }
+    Object.defineProperty MyApi.prototype, 'getThing', propertyDescriptor
+
+    # Random prototype read to make sure it's safe to scan the prototype
+    MyApi::getThing
+
+    myApi = new MyApi defaultConfig
+
+  it 'can be called without the request parameter', ->
+    myApi.getThing('zapp').then (reqMirror) ->
+      assert.equal '/v1/zapp?a=13', reqMirror.url


### PR DESCRIPTION
Removes the need for awkward `MyClient.prototype.registerEndpoints` calls when using Gofer with ES classes. Instead the following will work:

```js
class MyApi extends Gofer {
  serviceName = 'myApi';
  serviceVersion = 'myApi';

  @Gofer.Endpoint
  getThing(request, kind) {
    return request(`/v1/${kind}`);
  }
}
```