### PR TITLE
Add callback to proxy

### DIFF
--- a/lib/proxy.js
+++ b/lib/proxy.js
@@ -36,7 +36,7 @@ omit = require('lodash').omit;
 
 Url = require('url');
 
-module.exports = function(client, req, res, next) {
+module.exports = function(client, req, res, next, cb) {
   var options, pathname, properReturnValue, proxyReq, query, ref;
   ref = Url.parse(req.url, true), pathname = ref.pathname, query = ref.query;
   options = {
@@ -58,6 +58,9 @@ module.exports = function(client, req, res, next) {
   });
   properReturnValue = proxyReq != null;
   if (properReturnValue) {
+    if (cb != null) {
+      cb(proxyReq);
+    }
     return req.pipe(proxyReq).pipe(res);
   }
 };

--- a/src/proxy.coffee
+++ b/src/proxy.coffee
@@ -33,7 +33,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 {omit} = require 'lodash'
 Url = require 'url'
 
-module.exports = (client, req, res, next) ->
+module.exports = (client, req, res, next, cb) ->
   {pathname, query} = Url.parse req.url, true
 
   options =
@@ -58,4 +58,5 @@ module.exports = (client, req, res, next) ->
   properReturnValue = proxyReq?
 
   if properReturnValue
+    cb(proxyReq) if cb?
     req.pipe(proxyReq).pipe(res)

--- a/test/proxy.test.coffee
+++ b/test/proxy.test.coffee
@@ -27,8 +27,11 @@ describe 'proxy', ->
 
   next = ->
 
+  cbArgs = []
+  cb = -> cbArgs.push arguments
+
   before ->
-    proxy client, req, res, next
+    proxy client, req, res, next, cb
 
   it 'makes a request with the client', ->
     assert.expect requestArgs.length >= 1
@@ -50,3 +53,6 @@ describe 'proxy', ->
   it 'pipes the proxy request to the original request and response', ->
     assert.equal 'proxyReq', pipeArgs[0][0]
     assert.deepEqual res, pipeArgs[1][0]
+
+  it 'executes the callback function with the proxy request', ->
+    assert.equal 'proxyReq', cbArgs[0][0]


### PR DESCRIPTION
This is very useful when you need to add some event listeners on the proxy request:

```coffee
proxy = require 'gofer/proxy'

proxy client, req, res, next, (proxyReq) ->
  proxyReq.on 'data', (chunk) ->
    # ...

  proxyReq.on 'end', ->
    # ...
```