### PR TITLE
Filter out bad header chars for node v4

### DIFF
--- a/lib/hub.js
+++ b/lib/hub.js
@@ -30,7 +30,7 @@ LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
 NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-var DefaultPromise, EventEmitter, HRDuration, Hub, checkTimeout, debug, extend, formatUri, generateHeaders, generateUUID, http, https, isJsonResponse, map, promiseHelpers, ref, ref1, ref2, request, safeParseJSON, util, uuid;
+var DefaultPromise, EventEmitter, HRDuration, Hub, checkTimeout, debug, extend, formatUri, generateHeaders, generateUUID, http, https, isJsonResponse, map, mapValues, promiseHelpers, ref, ref1, ref2, removeInvalidHeaderChars, request, safeParseJSON, util, uuid;
 
 EventEmitter = require('events').EventEmitter;
 
@@ -46,7 +46,7 @@ HRDuration = require('hrduration');
 
 uuid = require('node-uuid');
 
-ref = require('lodash'), extend = ref.extend, map = ref.map;
+ref = require('lodash'), extend = ref.extend, map = ref.map, mapValues = ref.mapValues;
 
 debug = require('debug')('gofer:hub');
 
@@ -61,6 +61,10 @@ checkTimeout = function(timeout) {
     throw new Error(util.format('Invalid timeout: %j, not a number', timeout));
   }
   return timeout;
+};
+
+removeInvalidHeaderChars = function(header) {
+  return ("" + header).replace(/(?:\x7F|[^\x09\x20-\xFF])+/g, '');
 };
 
 module.exports = Hub = function() {
@@ -79,6 +83,7 @@ module.exports = Hub = function() {
     options.method = options.method != null ? options.method.toUpperCase() : 'GET';
     hubHeaders = generateHeaders(options.requestId, fetchId);
     extend(options.headers, hubHeaders);
+    options.headers = mapValues(options.headers, removeInvalidHeaderChars);
     logPendingRequests(http.globalAgent);
     logPendingRequests(https.globalAgent);
     responseData = {

--- a/test/hub/invalid-header.test.coffee
+++ b/test/hub/invalid-header.test.coffee
@@ -1,0 +1,12 @@
+assert = require 'assertive'
+hub = require('../../hub')()
+
+describe 'Invalid header', ->
+  it 'filters out invalid header chars', (done) ->
+    hub.fetch {
+      uri: 'http://foo.bar'
+      headers:
+        'x-bad': decodeURIComponent '%00'
+    }, (err, body, headers) ->
+      assert.equal 'getaddrinfo', err.syscall
+      done()

--- a/test/request.test.coffee
+++ b/test/request.test.coffee
@@ -23,7 +23,7 @@ MyApi::registerEndpoints {
     request '/zapp', { qs }, cb
 
   undefHeaders: (request) -> (cb) ->
-    headers = { a: undefined, b: null, c: 'non-null' }
+    headers = { a: undefined, b: null, c: 'non\tnull' }
     request '/zapp', { headers }, cb
 
   crash: (request) -> (cb) -> request '/crash', cb
@@ -119,7 +119,12 @@ describe 'actually making a request', ->
       assert.equal undefined, err?.stack
       assert.equal undefined, reqMirror.headers.a
       assert.equal undefined, reqMirror.headers.b
-      assert.equal 'non-null', reqMirror.headers.c
+      done()
+
+  it 'allows \t inside of headers', (done) ->
+    req = myApi.undefHeaders (err, reqMirror) ->
+      assert.equal undefined, err?.stack
+      assert.equal 'non\tnull', reqMirror.headers.c
       done()
 
   it 'fails early when an invalid timeout value is passed', ->


### PR DESCRIPTION
I tried pretty hard to find a way to reject calls using invalid header characters but given our current interface there's no way to do it afaict.

So the next best thing was to prevent crashes by sanitizing the header values.