### PR TITLE
Echo back the url in res.url

### DIFF
--- a/lib/fetch.browser.js
+++ b/lib/fetch.browser.js
@@ -165,6 +165,7 @@ function verifyAndExtendResponse(url, options, response) {
   Object.defineProperties(response, {
     statusCode: { value: response.status },
     headers: { get: getCachedHeaders },
+    url: { value: url },
   });
 
   function generateStatusCodeError(code) {

--- a/lib/request.js
+++ b/lib/request.js
@@ -97,6 +97,7 @@ function buildFullUrl(options) {
 function request_(options, resolve, reject) {
   var hostname = options.hostname;
   var setHost = options.setHost;
+  var fullUrl = buildFullUrl(options);
   options.setHost = false;
 
   var req_ = null;
@@ -142,7 +143,7 @@ function request_(options, resolve, reject) {
   function generateStatusCodeError() {
     var error = StatusCodeError.create(
       res_.statusCode, options.minStatusCode, options.maxStatusCode,
-      res_.headers, options.method, buildFullUrl(options));
+      res_.headers, options.method, fullUrl);
     res_.rawBody()
       .then(parseErrorBody)
       .then(null, noop)
@@ -159,6 +160,7 @@ function request_(options, resolve, reject) {
     timing.headers = Date.now() - startTime;
 
     res_ = Object.defineProperties(res, resProperties);
+    res_.url = fullUrl;
     res_.on('error', failAndAbort);
 
     if (!isAcceptableStatus(res.statusCode)) {

--- a/test/fetch-http.test.js
+++ b/test/fetch-http.test.js
@@ -18,6 +18,13 @@ describe('fetch: the basics', function () {
       });
   });
 
+  it('exposes the url on the response', function () {
+    return fetch(options.baseUrl + '/echo/foo/bar', { qs: { x: 42 } })
+      .then(function (res) {
+        assert.equal(options.baseUrl + '/echo/foo/bar?x=42', res.url);
+      });
+  });
+
   it('can load using path and baseUrl option', function () {
     return fetch('/text/path', { baseUrl: options.baseUrl })
       .then(function (res) {


### PR DESCRIPTION
This is really convenient when writing tests against API clients. Inspired by https://fetch.spec.whatwg.org/#dom-response-url.