### PR TITLE
Send valid host header

### DIFF
--- a/lib/fetch.js
+++ b/lib/fetch.js
@@ -220,6 +220,7 @@ function _fetch(urlObj, options) {
   return request({
     agent: agent,
     protocol: urlObj.protocol,
+    host: urlObj.host,
     hostname: hostname,
     port: urlObj.port,
     method: options.method || 'GET',

--- a/lib/request.js
+++ b/lib/request.js
@@ -95,7 +95,7 @@ function buildFullUrl(options) {
 }
 
 function request_(options, resolve, reject) {
-  var hostname = options.hostname;
+  var host = options.host;
   var setHost = options.setHost;
   options.setHost = false;
 
@@ -169,7 +169,7 @@ function request_(options, resolve, reject) {
   }
 
   function onResponseTimedOut() {
-    var error = new Error('Fetching from ' + hostname + ' timed out');
+    var error = new Error('Fetching from ' + host + ' timed out');
     error.code = 'ETIMEDOUT';
     error.timeout = options.timeout;
     error.timing = timing;
@@ -177,7 +177,7 @@ function request_(options, resolve, reject) {
   }
 
   function onConnectTimedOut() {
-    var error = new Error('Connection to ' + hostname + ' timed out');
+    var error = new Error('Connection to ' + host + ' timed out');
     error.code = 'ECONNECTTIMEDOUT';
     error.connectTimeout = options.connectTimeout;
     error.timing = timing;
@@ -207,7 +207,7 @@ function request_(options, resolve, reject) {
     req.once('socket', onSocket);
 
     if (setHost !== false && !req.getHeader('Host')) {
-      req.setHeader('Host', hostname);
+      req.setHeader('Host', host);
     }
 
     var body = options.body;

--- a/lib/url.js
+++ b/lib/url.js
@@ -48,6 +48,7 @@ function applyBaseUrl(urlObj, baseUrl) {
     // Protocol/auth/hostname/port always apply
     protocol: base.protocol,
     auth: base.auth,
+    host: base.host,
     hostname: base.hostname,
     port: base.port,
 

--- a/test/fetch-http.test.js
+++ b/test/fetch-http.test.js
@@ -151,6 +151,22 @@ describe('fetch: the basics', function () {
       });
   });
 
+  describe('host header', function () {
+    it('sends a valid host header', function () {
+      return fetch(options.baseUrl + '/echo').json()
+        .then(function (echo) {
+          assert.equal('localhost:3066', echo.headers.host);
+        });
+    });
+
+    it('sends a valid host header with baseUrl', function () {
+      return fetch('/echo', { baseUrl: options.baseUrl }).json()
+        .then(function (echo) {
+          assert.equal('localhost:3066', echo.headers.host);
+        });
+    });
+  });
+
   it('allows passing headers', function () {
     return fetch('/echo', {
       baseUrl: options.baseUrl,


### PR DESCRIPTION
Previously it was sending `localhost` instead of `localhost:3066` which is invalid behavior according to the HTTP spec.