### PR TITLE
Support isomorphic-fetch

### DIFF
--- a/lib/fetch.browser.js
+++ b/lib/fetch.browser.js
@@ -152,7 +152,7 @@ function verifyAndExtendResponse(url, options, response) {
   var cachedHeaders;
   function getCachedHeaders() {
     if (!cachedHeaders) {
-      cachedHeaders = {};
+      cachedHeaders = Object.create(originalHeaders);
       originalHeaders.forEach(function addHeader(value, name) {
         if (name) {
           cachedHeaders[name] = value;


### PR DESCRIPTION
`isomorphic-fetch` tries to call `this.headers.get` while processing the body. The previous code broke that behavior.