### PR TITLE
Bring back debug support

### DIFF
--- a/lib/request.js
+++ b/lib/request.js
@@ -36,6 +36,7 @@ var https = require('https');
 var formatUrl = require('url').format;
 
 var Bluebird = require('bluebird');
+var debug = require('debug')('gofer');
 
 var StatusCodeError = require('./errors').StatusCodeError;
 var resProperties = require('./response');
@@ -99,6 +100,7 @@ function request_(options, resolve, reject) {
   var setHost = options.setHost;
   var fullUrl = buildFullUrl(options);
   options.setHost = false;
+  debug('-> %s %s', options.method, fullUrl);
 
   var req_ = null;
   var res_ = null;
@@ -113,6 +115,7 @@ function request_(options, resolve, reject) {
   };
 
   function failAndAbort(error) {
+    debug('<- %s %s', error.code || error.statusCode, fullUrl);
     clearTimeout(connectTimer);
     connectTimer = null;
     clearTimeout(responseTimer);
@@ -166,6 +169,7 @@ function request_(options, resolve, reject) {
     if (!isAcceptableStatus(res.statusCode)) {
       generateStatusCodeError();
     } else {
+      debug('<- %s %s', res.statusCode, fullUrl);
       resolve(res_);
     }
   }

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
   },
   "dependencies": {
     "bluebird": "^3.3.3",
+    "debug": "^2.2.0",
     "lodash": "^4.6.1",
     "qs": "^6.1.0",
     "url": "^0.11.0"


### PR DESCRIPTION
Apparently I missed one of my favorite features in 3.x. Now `DEBUG=gofer* do-stuff` is helpful again.