### PR TITLE
Support gofer 3 in gofer/proxy

### DIFF
--- a/lib/gofer.js
+++ b/lib/gofer.js
@@ -30,8 +30,12 @@ LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
 NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-var GOOD_FORM_ENCODED, Gofer, Hub, applyBaseUrl, buildUserAgent, cleanObject, extend, isJsonResponse, merge, parseDefaults, ref, ref1, resolveOptional, safeParseJSON,
+var Bluebird, GOOD_FORM_ENCODED, Gofer, Hub, Readable, applyBaseUrl, buildUserAgent, cleanObject, extend, isJsonResponse, merge, parseDefaults, ref, ref1, resolveOptional, safeParseJSON, wrapErrorInStream,
   bind = function(fn, me){ return function(){ return fn.apply(me, arguments); }; };
+
+Readable = require('stream').Readable;
+
+Bluebird = require('bluebird');
 
 extend = require('lodash').extend;
 
@@ -42,6 +46,44 @@ ref = require('./helpers'), resolveOptional = ref.resolveOptional, parseDefaults
 ref1 = require('./json'), safeParseJSON = ref1.safeParseJSON, isJsonResponse = ref1.isJsonResponse;
 
 GOOD_FORM_ENCODED = 'application/x-www-form-urlencoded; charset=utf-8';
+
+wrapErrorInStream = function(callback, error) {
+  var errorEmitted, getRejectPromise, stream;
+  stream = new Readable();
+  stream._read = function() {};
+  if (typeof callback === 'function') {
+    stream.on('error', callback);
+  }
+  errorEmitted = false;
+  setImmediate(function() {
+    errorEmitted = true;
+    return stream.emit('error', error);
+  });
+  getRejectPromise = function() {
+    if (errorEmitted) {
+      return Bluebird.reject(error);
+    }
+    return new Bluebird(function(resolve, reject) {
+      return stream.on('error', reject);
+    });
+  };
+  return Object.defineProperties(stream, {
+    asPromise: {
+      value: getRejectPromise
+    },
+    getBody: {
+      value: getRejectPromise
+    },
+    getResponse: {
+      value: getRejectPromise
+    },
+    then: {
+      value: function(onError, onSuccess) {
+        return this.getBody().then(onError, onSuccess);
+      }
+    }
+  });
+};
 
 Gofer = (function() {
   function Gofer(config, hub) {
@@ -194,7 +236,7 @@ Gofer = (function() {
       options = this._applyMappers(merge(defaults, options));
     } catch (error1) {
       err = error1;
-      return cb(err);
+      return wrapErrorInStream(cb, err);
     }
     if (options.headers == null) {
       options.headers = {};

--- a/lib/proxy.js
+++ b/lib/proxy.js
@@ -30,35 +30,33 @@ LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
 NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-var Url, omit;
+var Bluebird, Url, omit;
+
+Bluebird = require('bluebird');
 
 omit = require('lodash').omit;
 
 Url = require('url');
 
 module.exports = function(client, req, res, next) {
-  var options, pathname, properReturnValue, proxyReq, query, ref;
+  var handleProxyResponse, options, pathname, piped, proxyReq, query, ref;
   ref = Url.parse(req.url, true), pathname = ref.pathname, query = ref.query;
   options = {
     method: req.method,
     headers: omit(req.headers, ['host']),
-    uri: pathname,
+    body: req,
     qs: omit(query, ['callback']),
     minStatusCode: 200,
     maxStatusCode: 399
   };
-  properReturnValue = false;
-  proxyReq = client.request(options, function(err) {
-    if (properReturnValue) {
-      return;
-    }
-    if (err != null) {
-      return next(err);
-    }
-  });
-  properReturnValue = proxyReq != null;
-  if (properReturnValue) {
-    proxyReq.on('error', next);
-    return req.pipe(proxyReq).pipe(res);
-  }
+  proxyReq = client.fetch(pathname, options);
+  handleProxyResponse = function(proxyRes) {
+    return new Bluebird(function(resolve, reject) {
+      proxyRes.on('error', reject);
+      proxyRes.pipe(res);
+      return proxyRes.on('end', resolve);
+    });
+  };
+  piped = typeof proxyReq.pipe === 'function' ? handleProxyResponse(proxyReq) : proxyReq.then(handleProxyResponse);
+  return piped.then(null, next);
 };

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "hrduration": "^1.0.0",
     "lodash": "^4.6.1",
     "node-uuid": "^1.4.1",
-    "request": "2.57.0"
+    "request": "2.74.0"
   },
   "devDependencies": {
     "assertive": "^2.0.0",

--- a/test/promise_helpers.test.coffee
+++ b/test/promise_helpers.test.coffee
@@ -65,6 +65,10 @@ describe 'promiseHelpers', ->
       crash: crashEndpoint
     }
 
+    MyApi::addOptionMapper (options) ->
+      throw new Error 'ForcedThrow' if options.forceThrow
+      options
+
     myApi = new MyApi defaultConfig
 
   it 'reacts properly to low-level errors', ->
@@ -88,3 +92,23 @@ describe 'promiseHelpers', ->
   it 'can act as a pseudo-thenable', ->
     myApi.query().then (reqMirror) ->
       assert.equal '/v1/zapp?p=1', reqMirror.url
+
+  it 'passes through option mapper errors to .then', ->
+    myApi.with(forceThrow: true).zapp().then().then unexpected, (err) ->
+      assert.equal 'ForcedThrow', err.message
+
+  it 'passes through option mapper errors to .then(onSuccess, onError)', ->
+    myApi.with(forceThrow: true).zapp().then unexpected, (err) ->
+      assert.equal 'ForcedThrow', err.message
+
+  it 'passes through option mapper errors to .getBody', ->
+    myApi.with(forceThrow: true).zapp().getBody().then unexpected, (err) ->
+      assert.equal 'ForcedThrow', err.message
+
+  it 'passes through option mapper errors to .getResponse', ->
+    myApi.with(forceThrow: true).zapp().getResponse().then unexpected, (err) ->
+      assert.equal 'ForcedThrow', err.message
+
+  it 'passes through option mapper errors to .asPromise', ->
+    myApi.with(forceThrow: true).zapp().asPromise().then unexpected, (err) ->
+      assert.equal 'ForcedThrow', err.message

--- a/test/proxy.test.coffee
+++ b/test/proxy.test.coffee
@@ -1,85 +1,136 @@
+'use strict'
+http = require 'http'
 {EventEmitter} = require 'events'
 
 assert = require 'assertive'
-proxy = require '../lib/proxy'
+express = require 'express'
+Gofer = require '../'
+
+expressProxy = require '../proxy'
+
+class EchoClient extends Gofer
+  serviceName: 'echo'
+
+EchoClient.prototype.addOptionMapper (options) ->
+  if options.headers['x-fail-mapper']
+    throw new Error 'OptionMapperError'
+
+  options
+
+class ProxyClient extends Gofer
+  serviceName: 'proxy'
 
 describe 'proxy', ->
-  describe 'fragile internals test', ->
-    requestArgs = []
+  echoClient = null
+  proxyClient = null
 
-    proxyReq =
-      on: ->
+  before 'setup echo app', (done) ->
+    echoServer = http.createServer (req, res) ->
+      {url, method, headers} = req
 
-    client =
-      request: ->
-        requestArgs.push arguments
-        proxyReq
+      if url.indexOf('network-error') != -1
+        req.socket.destroy()
+        return # ECONNRESET
 
-    pipeArgs = []
-    pipe = ->
-      pipeArgs.push arguments
-      this
+      if headers['if-none-match']
+        res.statusCode = 304
+        res.end()
+        return
 
-    req =
-      pipe: pipe
-      url: 'www.something.com/some-url?search=show-me-the-request'
-      method: 'some-method'
-      headers:
-        some: 'some-headers'
-        host: 'host-header'
-        other: 'other-header'
+      res.statusCode = 401 if url.indexOf('server-error') != -1
+      res.setHeader 'Content-Type', 'application/json'
+      chunks = []
+      req.on 'data', (chunk) -> chunks.push chunk
+      req.on 'end', ->
+        body = Buffer.concat(chunks).toString 'utf8'
+        res.end JSON.stringify {url, method, headers, body}
 
-    res = {}
+    echoServer.listen 0, ->
+      echoClient = new EchoClient {
+        echo:
+          baseUrl: "http://127.0.0.1:#{echoServer.address().port}/other/base"
+          qs:
+            client_id: 'some-client-id'
+      }
+      done()
 
-    next = ->
+  before 'setup proxy app', (done) ->
+    proxyApp = express()
+    proxyApp.use '/api/v2', (req, res, next) ->
+      expressProxy echoClient, req, res, next
 
-    before ->
-      proxy client, req, res, next
+    proxyApp.use (err, req, res, next) ->
+      res.statusCode = 500
+      res.json {
+        fromErrorMiddleware: true
+        message: err.message
+        code: err.code
+        syscall: err.syscall
+      }
 
-    it 'makes a request with the client', ->
-      assert.expect requestArgs.length >= 1
+    proxyServer = http.createServer proxyApp
+    proxyServer.listen 0, ->
+      proxyClient = new ProxyClient {
+        proxy:
+          minStatusCode: 200
+          maxStatusCode: 599
+          baseUrl: "http://127.0.0.1:#{proxyServer.address().port}"
+      }
+      done()
 
-    it 'uses the correct parameters', ->
-      expectedRequestArgs =
-        method: 'some-method'
-        headers:
-          some: 'some-headers'
-          other: 'other-header'
-        uri: 'www.something.com/some-url'
-        qs:
-          search: 'show-me-the-request'
-        minStatusCode: 200
-        maxStatusCode: 399
-
-      assert.deepEqual expectedRequestArgs, requestArgs[0][0]
-
-    it 'pipes the proxy request to the original request and response', ->
-      assert.equal proxyReq, pipeArgs[0][0]
-      assert.deepEqual res, pipeArgs[1][0]
-
-  describe 'with failing request', ->
-    nextError = null
-
-    req =
-      url: '/some/path'
-      pipe: (target) -> target
-
-    res = {}
-
-    client =
-      request: ->
-        clientRequest = new EventEmitter()
-        clientRequest.pipe = (target) -> target
-        process.nextTick ->
-          clientRequest.on 'error', ->
-            'ignoring because that is what request does'
-          clientRequest.emit 'error', new Error 'some-error'
-        clientRequest
-
+  describe 'successful request', ->
+    reqEcho = null
     before (done) ->
-      proxy client, req, res, (err) ->
-        nextError = err
-        done()
+      proxyClient.fetch '/api/v2/some/path?x=42', {
+        method: 'POST'
+        json: { some: { body: 'data' } }
+        qs: { more: 'query stuff' }
+      }, (err, data) ->
+        reqEcho = data
+        done err
 
-    it 'forwards errors to next', ->
-      assert.equal 'some-error', nextError.message
+    it 'forwards the method', ->
+      assert.equal 'POST', reqEcho.method
+
+    it 'removes the middleware mount point from the url', ->
+      [urlPath, query] = reqEcho.url.split '?'
+      assert.equal '/other/base/some/path', urlPath
+      assert.equal 'client_id=some-client-id&x=42&more=query%20stuff', query
+
+    it 'forwards the request body', ->
+      assert.equal '{"some":{"body":"data"}}', reqEcho.body
+
+  it 'forwards 304s', ->
+    proxyClient.fetch('/api/v2/not-modified', {
+      headers:
+        'if-none-match': 'last-etag'
+    }).asPromise().then ([body, res]) ->
+      assert.equal 304, res.statusCode
+      assert.equal '', body
+
+  it 'fails cleanly with a throwing option mapper', ->
+    proxyClient.fetch('/api/v2/some/path', {
+      headers: { 'x-fail-mapper': '1' }
+    }).then (error) ->
+      assert.expect error.fromErrorMiddleware
+      assert.equal 'OptionMapperError', error.message
+
+  it 'forwards 4xx', ->
+    proxyClient.fetch('/api/v2/server-error', {
+      method: 'POST'
+      json: { some: { body: 'data' } }
+      qs: { more: 'query stuff' }
+      headers:
+        'x-my-header': 'header-value'
+    }).asPromise().then ([body, res]) ->
+      assert.equal 401, res.statusCode
+      assert.equal 'header-value', body.headers['x-my-header']
+
+  it 'wraps network errors', ->
+    proxyClient.fetch('/api/v2/network-error', {
+      method: 'POST'
+      json: { some: { body: 'data' } }
+      qs: { more: 'query stuff' }
+    }).then (error) ->
+      assert.expect error.fromErrorMiddleware
+      assert.equal 'ECONNRESET', error.code


### PR DESCRIPTION
Tested manually against a gofer 3.x client. Long-term we should move this file into its own module and make sure we test it against both major versions of gofer.