### PR TITLE
Support searchDomain option

### DIFF
--- a/API.md
+++ b/API.md
@@ -28,6 +28,9 @@ import { fetch } from 'gofer';
 * `maxSockets`: Maximum number of parallel requests to the same domain. `gofer` will never use the global http(s) agent but will instead keep agents per client class.
 * `timeout`: Response- and socket read timeout in milliseconds.
 * `connectTimeout`: Timeout in milliseconds for the time between acquiring a socket and establishing a connection to the remote host. This should generally be relatively low.
+* `searchDomain`: Inspired by the `search` setting in `/etc/resolv.conf`.
+  Append this to any hostname that doesn't already end in a ".".
+  E.g. `my-hostname` turns into `my-hostname.<searchDomain>.` but `my.fully.qualified.name.` won't be touched.
 
 ## `Gofer`
 

--- a/lib/fetch.js
+++ b/lib/fetch.js
@@ -196,6 +196,10 @@ function _fetch(urlObj, options) {
     throw new Error('Invalid URI ' + JSON.stringify(hostname));
   }
 
+  if (options.searchDomain && hostname[hostname.length - 1] !== '.') {
+    hostname += '.' + options.searchDomain + '.';
+  }
+
   var agent = getAgent(options, urlObj);
   assign(agent.options, {
     // http:

--- a/test/fetch-search-domain.test.js
+++ b/test/fetch-search-domain.test.js
@@ -1,0 +1,56 @@
+'use strict';
+var assert = require('assertive');
+
+var fetch = require('../').fetch;
+
+describe('fetch: searchDomain', function () {
+  if (typeof document !== 'undefined') {
+    // This is not really a feature relevant for client-side code.
+    it('is not implemented');
+    return;
+  }
+
+  it('appends the searchDomain to non-fqdns in uri', function () {
+    var options = { searchDomain: 'bar123' };
+    return assert.rejects(fetch('http://some.invalid.thing/a/path', options))
+      .then(function (error) {
+        assert.equal('ENOTFOUND', error.code);
+        if ('hostname' in error) { // node 4.x+
+          assert.equal('some.invalid.thing.bar123.', error.hostname);
+        }
+      });
+  });
+
+  it('appends the searchDomain to non-fqdns in baseUrl', function () {
+    var options = { baseUrl: 'http://some.invalid.thing/a', searchDomain: 'bar123' };
+    return assert.rejects(fetch('/path', options))
+      .then(function (error) {
+        assert.equal('ENOTFOUND', error.code);
+        if ('hostname' in error) { // node 4.x+
+          assert.equal('some.invalid.thing.bar123.', error.hostname);
+        }
+      });
+  });
+
+  it('never appends the searchDomain to fqdns in uri', function () {
+    var options = { searchDomain: 'bar123' };
+    return assert.rejects(fetch('http://some.invalid.thing./a/path', options))
+      .then(function (error) {
+        assert.equal('ENOTFOUND', error.code);
+        if ('hostname' in error) { // node 4.x+
+          assert.equal('some.invalid.thing.', error.hostname);
+        }
+      });
+  });
+
+  it('never appends the searchDomain to fqdns in baseUrl', function () {
+    var options = { baseUrl: 'http://some.invalid.thing./a', searchDomain: 'bar123' };
+    return assert.rejects(fetch('/path', options))
+      .then(function (error) {
+        assert.equal('ENOTFOUND', error.code);
+        if ('hostname' in error) { // node 4.x+
+          assert.equal('some.invalid.thing.', error.hostname);
+        }
+      });
+  });
+});


### PR DESCRIPTION
Pretty straight-forward - if you specify a `searchDomain`, it will be appended to all hostnames unless they already are [fully qualified](https://en.wikipedia.org/wiki/Fully_qualified_domain_name).