### PR TITLE
Fire IO timeouts after IO

### DIFF
--- a/lib/gofer.js
+++ b/lib/gofer.js
@@ -221,7 +221,7 @@ Gofer = (function() {
   };
 
   Gofer.prototype._request = function(options, cb) {
-    var base, defaults, err, error1, ref2, req;
+    var base, defaults, err, ref2, req;
     defaults = this._getDefaults(this.defaults, options);
     if (options.methodName == null) {
       options.methodName = ((ref2 = options.method) != null ? ref2 : 'get').toLowerCase();

--- a/lib/hub.js
+++ b/lib/hub.js
@@ -30,7 +30,7 @@ LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
 NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-var DefaultPromise, EventEmitter, HRDuration, Hub, checkTimeout, debug, extend, formatUri, generateHeaders, generateUUID, http, https, isJsonResponse, map, mapValues, promiseHelpers, ref, ref1, ref2, removeInvalidHeaderChars, request, safeParseJSON, util, uuid;
+var DefaultPromise, EventEmitter, HRDuration, Hub, checkTimeout, clearIOTimeout, debug, extend, formatUri, generateHeaders, generateUUID, http, https, isJsonResponse, map, mapValues, once, promiseHelpers, ref, ref1, ref2, removeInvalidHeaderChars, request, safeParseJSON, setIOTimeout, util, uuid;
 
 EventEmitter = require('events').EventEmitter;
 
@@ -46,7 +46,7 @@ HRDuration = require('hrduration');
 
 uuid = require('node-uuid');
 
-ref = require('lodash'), extend = ref.extend, map = ref.map, mapValues = ref.mapValues;
+ref = require('lodash'), extend = ref.extend, map = ref.map, mapValues = ref.mapValues, once = ref.once;
 
 debug = require('debug')('gofer:hub');
 
@@ -67,15 +67,56 @@ removeInvalidHeaderChars = function(header) {
   return ("" + header).replace(/(?:\x7F|[^\x09\x20-\xFF])+/g, '');
 };
 
+setIOTimeout = function(callback, ms) {
+  var cancel, delayHandle, done, initialHandle, onDelay, onTimer;
+  initialHandle = null;
+  delayHandle = null;
+  done = false;
+  onDelay = function() {
+    if (done) {
+      return;
+    }
+    done = true;
+    delayHandle = null;
+    return callback();
+  };
+  onTimer = function() {
+    if (done) {
+      return;
+    }
+    initialHandle = null;
+    return delayHandle = setImmediate(onDelay);
+  };
+  cancel = function() {
+    if (done) {
+      return;
+    }
+    done = true;
+    clearTimeout(initialHandle);
+    clearImmediate(delayHandle);
+    return initialHandle = delayHandle = null;
+  };
+  initialHandle = setTimeout(onTimer, ms);
+  return cancel;
+};
+
+clearIOTimeout = function(handle) {
+  if (!handle) {
+    return;
+  }
+  return handle();
+};
+
 module.exports = Hub = function() {
   var hub, logPendingRequests, setupCompletionTimeout, setupTimeouts;
   hub = new EventEmitter;
   hub.Promise = DefaultPromise;
   hub.fetch = function(options, done) {
-    var baseLog, completionTimeoutInterval, connectTimeoutInterval, fetchId, getSeconds, handleResult, hubHeaders, ref3, ref4, req, responseData, sendResult;
+    var baseLog, completionTimeoutInterval, connectTimeoutInterval, fetchId, getSeconds, handleResult, headerTimeoutInterval, hubHeaders, ref3, ref4, req, responseData, sendResult;
     getSeconds = HRDuration().getSeconds;
     fetchId = generateUUID();
-    options.timeout = checkTimeout((ref3 = options.timeout) != null ? ref3 : Hub.requestTimeout);
+    headerTimeoutInterval = checkTimeout((ref3 = options.timeout) != null ? ref3 : Hub.requestTimeout);
+    delete options.timeout;
     connectTimeoutInterval = checkTimeout((ref4 = options.connectTimeout) != null ? ref4 : Hub.connectTimeout);
     if (options.headers == null) {
       options.headers = {};
@@ -166,7 +207,7 @@ module.exports = Hub = function() {
     };
     req = request(options, handleResult);
     completionTimeoutInterval = options.completionTimeout;
-    setupTimeouts(connectTimeoutInterval, completionTimeoutInterval, req, responseData, getSeconds);
+    setupTimeouts(headerTimeoutInterval, connectTimeoutInterval, completionTimeoutInterval, req, responseData, getSeconds);
     if (typeof done === 'function') {
       req.on('goferResult', done);
     }
@@ -193,8 +234,30 @@ module.exports = Hub = function() {
       queueReport: queueReport
     });
   };
-  setupTimeouts = function(connectTimeoutInterval, completionTimeoutInterval, request, responseData, getSeconds) {
+  setupTimeouts = function(headerTimeoutInterval, connectTimeoutInterval, completionTimeoutInterval, request, responseData, getSeconds) {
     return request.on('request', function(req) {
+      var fireTimeoutError, headerTimeout, onHeadersReceived;
+      fireTimeoutError = once(function() {
+        var e;
+        if (!request.req) {
+          return;
+        }
+        req.abort();
+        e = new Error('ETIMEDOUT');
+        e.code = 'ETIMEDOUT';
+        e.connect = req.socket && req.socket.readable === false;
+        return request.emit('error', e);
+      });
+      req.setTimeout(headerTimeoutInterval, function() {
+        return req.setTimeout(1, function() {
+          return fireTimeoutError;
+        });
+      });
+      headerTimeout = setIOTimeout(fireTimeoutError, headerTimeoutInterval);
+      onHeadersReceived = function() {
+        return clearIOTimeout(headerTimeout);
+      };
+      req.on('response', onHeadersReceived);
       return req.on('socket', function(socket) {
         var connectTimeout, connectingSocket, connectionSuccessful, connectionTimedOut, ref3;
         connectTimeout = void 0;
@@ -211,13 +274,13 @@ module.exports = Hub = function() {
         connectionSuccessful = function() {
           responseData.connectDuration = getSeconds();
           hub.emit('connect', responseData);
-          clearTimeout(connectTimeout);
+          clearIOTimeout(connectTimeout);
           connectTimeout = null;
           return setupCompletionTimeout(completionTimeoutInterval, req, responseData, getSeconds);
         };
         connectingSocket = (ref3 = socket.socket) != null ? ref3 : socket;
         connectingSocket.on('connect', connectionSuccessful);
-        return connectTimeout = setTimeout(connectionTimedOut, connectTimeoutInterval);
+        return connectTimeout = setIOTimeout(connectionTimedOut, connectTimeoutInterval);
       });
     });
   };

--- a/lib/hub.js
+++ b/lib/hub.js
@@ -237,20 +237,25 @@ module.exports = Hub = function() {
   setupTimeouts = function(headerTimeoutInterval, connectTimeoutInterval, completionTimeoutInterval, request, responseData, getSeconds) {
     return request.on('request', function(req) {
       var fireTimeoutError, headerTimeout, onHeadersReceived;
-      fireTimeoutError = once(function() {
+      fireTimeoutError = once(function(code) {
         var e;
+        if (code == null) {
+          code = 'ETIMEDOUT';
+        }
         if (!request.req) {
           return;
         }
         req.abort();
-        e = new Error('ETIMEDOUT');
-        e.code = 'ETIMEDOUT';
+        e = new Error(code);
+        e.code = code;
         e.connect = req.socket && req.socket.readable === false;
         return request.emit('error', e);
       });
       req.setTimeout(headerTimeoutInterval, function() {
-        return req.setTimeout(1, function() {
-          return fireTimeoutError;
+        return setImmediate(function() {
+          if (req.socket && req.socket.readable) {
+            return fireTimeoutError('ESOCKETTIMEDOUT');
+          }
         });
       });
       headerTimeout = setIOTimeout(fireTimeoutError, headerTimeoutInterval);

--- a/lib/json.js
+++ b/lib/json.js
@@ -35,7 +35,7 @@ var GOFER_PARSED, jsonHeader, nonEmpty;
 GOFER_PARSED = 'GOFER_PARSED_RESPONSE';
 
 this.safeParseJSON = function(str, res) {
-  var data, err, error;
+  var data, err;
   if (res == null) {
     return {};
   }

--- a/src/hub.coffee
+++ b/src/hub.coffee
@@ -38,7 +38,7 @@ util = require 'util'
 request = require 'request'
 HRDuration = require 'hrduration'
 uuid = require 'node-uuid'
-{extend, map, mapValues} = require 'lodash'
+{extend, map, mapValues, once} = require 'lodash'
 debug = require('debug') 'gofer:hub'
 DefaultPromise = global.Promise ? require 'bluebird'
 
@@ -62,6 +62,36 @@ removeInvalidHeaderChars = (header) ->
   # Where `ch` is a character code (e.g. `str.charCodeAt(idx)`)
   "#{header}".replace /(?:\x7F|[^\x09\x20-\xFF])+/g, ''
 
+setIOTimeout = (callback, ms) ->
+  initialHandle = null
+  delayHandle = null
+  done = false
+
+  onDelay = ->
+    return if done
+    done = true
+    delayHandle = null
+    callback()
+
+  onTimer = ->
+    return if done
+    initialHandle = null
+    delayHandle = setImmediate onDelay
+
+  cancel = ->
+    return if done
+    done = true
+    clearTimeout initialHandle
+    clearImmediate delayHandle
+    initialHandle = delayHandle = null
+
+  initialHandle = setTimeout onTimer, ms
+  return cancel
+
+clearIOTimeout = (handle) ->
+  return unless handle
+  handle()
+
 # Default timeout intervals
 module.exports = Hub = ->
   hub = new EventEmitter
@@ -72,7 +102,8 @@ module.exports = Hub = ->
 
     fetchId = generateUUID()
 
-    options.timeout = checkTimeout options.timeout ? Hub.requestTimeout
+    headerTimeoutInterval = checkTimeout options.timeout ? Hub.requestTimeout
+    delete options.timeout
     connectTimeoutInterval = checkTimeout options.connectTimeout ? Hub.connectTimeout
 
     options.headers ?= {}
@@ -163,7 +194,7 @@ module.exports = Hub = ->
     req = request options, handleResult
 
     completionTimeoutInterval = options.completionTimeout
-    setupTimeouts connectTimeoutInterval, completionTimeoutInterval, req, responseData, getSeconds
+    setupTimeouts headerTimeoutInterval, connectTimeoutInterval, completionTimeoutInterval, req, responseData, getSeconds
 
     if typeof done == 'function'
       req.on 'goferResult', done
@@ -182,8 +213,26 @@ module.exports = Hub = ->
   # connection to the remote server to be established. It is standard practice
   # for this value to be significantly lower than the "request" timeout when
   # making requests to internal endpoints.
-  setupTimeouts = (connectTimeoutInterval, completionTimeoutInterval, request, responseData, getSeconds) ->
+  setupTimeouts = (headerTimeoutInterval, connectTimeoutInterval, completionTimeoutInterval, request, responseData, getSeconds) ->
     request.on 'request', (req) ->
+      fireTimeoutError = once ->
+        # Ported from request's timeout logic
+        return unless request.req
+        req.abort()
+        e = new Error 'ETIMEDOUT'
+        e.code = 'ETIMEDOUT'
+        e.connect = req.socket && req.socket.readable == false
+        request.emit 'error', e
+
+      req.setTimeout headerTimeoutInterval, ->
+        req.setTimeout 1, -> fireTimeoutError
+
+      headerTimeout = setIOTimeout fireTimeoutError, headerTimeoutInterval
+
+      onHeadersReceived = -> clearIOTimeout headerTimeout
+
+      req.on 'response', onHeadersReceived
+
       req.on 'socket', (socket) ->
         connectTimeout = undefined
         connectionTimedOut = ->
@@ -202,14 +251,14 @@ module.exports = Hub = ->
           responseData.connectDuration = getSeconds()
           hub.emit 'connect', responseData
 
-          clearTimeout connectTimeout
+          clearIOTimeout connectTimeout
           connectTimeout = null
 
           setupCompletionTimeout completionTimeoutInterval, req, responseData, getSeconds
 
         connectingSocket = socket.socket ? socket
         connectingSocket.on 'connect', connectionSuccessful
-        connectTimeout = setTimeout connectionTimedOut, connectTimeoutInterval
+        connectTimeout = setIOTimeout connectionTimedOut, connectTimeoutInterval
 
   # This will setup a timer to make sure we don't wait to long for the response
   # to complete. The semantics are as follows:

--- a/test/hub/_remote_server
+++ b/test/hub/_remote_server
@@ -1,0 +1,39 @@
+'use strict';
+var childProcess = require('child_process');
+var http = require('http');
+
+var SERVER_LISTEN = 'gofer-server-listen';
+
+var child;
+var server;
+
+exports.port = null;
+
+exports.fork = function fork(done) {
+  child = childProcess.fork(__filename);
+  child.on('message', function onChildMessage(message) {
+    if (message.kind === SERVER_LISTEN) {
+      exports.port = message.port;
+      done();
+    } else {
+      console.error(message);
+    }
+  });
+};
+
+exports.kill = function kill(done) {
+  child.kill();
+  done();
+};
+
+if (module === process.mainModule) {
+  server = http.createServer(function onRequest(req, res) {
+    setTimeout(function () {
+      res.end('ok');
+    }, 50);
+  });
+
+  server.listen(0, function onListen() {
+    process.send({ kind: SERVER_LISTEN, port: server.address().port });
+  });
+}

--- a/test/hub/_remote_server
+++ b/test/hub/_remote_server
@@ -29,7 +29,10 @@ exports.kill = function kill(done) {
 if (module === process.mainModule) {
   server = http.createServer(function onRequest(req, res) {
     setTimeout(function () {
-      res.end('ok');
+      res.writeHead(200);
+      setTimeout(function () {
+        res.end('ok');
+      }, 50);
     }, 50);
   });
 

--- a/test/hub/timeout.test.coffee
+++ b/test/hub/timeout.test.coffee
@@ -3,6 +3,7 @@ assert = require 'assertive'
 hub = require('../../hub')()
 
 serverBuilder = require './_test_server'
+remoteServer = require './_remote_server'
 
 checkRequestOptions = (err) ->
   assert.expect 'Includes responseData.requestOptions', err.responseData?.requestOptions?
@@ -19,6 +20,28 @@ describe 'Basic Integration Test', ->
 
   after (done) ->
     @server.close done
+
+  describe 'timeout in the presence of blocking event loop', ->
+
+    before remoteServer.fork
+
+    after remoteServer.kill
+
+    it 'gives it a last chance', (done) ->
+      @timeout 500
+
+      hub.fetch {
+        uri: "http://127.0.0.1:#{remoteServer.port}"
+        timeout: 100
+      }, (err, body, headers) ->
+        done err
+
+      blockEventLoop = ->
+        endTime = Date.now() + 150
+        while Date.now() < endTime
+          endTime = endTime
+
+      setTimeout blockEventLoop, 20
 
   describe 'connect timeout', ->
 
@@ -41,15 +64,15 @@ describe 'Basic Integration Test', ->
     it 'does not pass an error when timeout is not exceeded', (done) ->
       hub.fetch {
         uri: "http://127.0.0.1:#{@port}"
-        qs: {__latency: 10}
-        timeout: 20
+        qs: {__latency: 20}
+        timeout: 60
       }, (err, body, headers) ->
         done err
 
     it 'passes an error when timeout is exceeded', (done) ->
       hub.fetch {
         uri: "http://127.0.0.1:#{@port}"
-        qs: {__latency: 30}
+        qs: {__latency: 60}
         timeout: 20
       }, (err, body, headers) ->
         assert.equal 'ETIMEDOUT', err?.code

--- a/test/hub/timeout.test.coffee
+++ b/test/hub/timeout.test.coffee
@@ -79,6 +79,19 @@ describe 'Basic Integration Test', ->
         checkRequestOptions err
         done()
 
+  describe 'socket timeout', ->
+    it 'emits a ESOCKETTIMEDOUT', (done) ->
+      @timeout 500
+
+      hub.fetch {
+        uri: "http://127.0.0.1:#{@port}"
+        qs: {__delay: 100}
+        timeout: 50
+      }, (err, body, headers) ->
+        assert.equal 'ESOCKETTIMEDOUT', err?.code
+        checkRequestOptions err
+        done()
+
   describe 'completion timeout', ->
 
     it 'does not pass an error when timeout is not exceeded', (done) ->


### PR DESCRIPTION
The node event loop processes all timeouts before IO events. This
is fine - unless we receive a response in the same tick that our
response timeout fires. When that happens, we fail the request
even though we actually received a perfectly fine response already.

This PR delays all IO timeouts by one tick, making sure that we
don't discard data we already received.