### PR TITLE
Verify completion timeout behavior

### DIFF
--- a/lib/hub.js
+++ b/lib/hub.js
@@ -301,6 +301,7 @@ module.exports = Hub = function() {
       responseData.completionDuration = getSeconds() - responseData.connectDuration;
       err = new Error('ETIMEDOUT');
       err.code = 'ETIMEDOUT';
+      err.completion = true;
       err.message = "Response timed out after " + completionTimeoutInterval + "ms";
       err.responseData = responseData;
       return req.emit('error', err);

--- a/src/hub.coffee
+++ b/src/hub.coffee
@@ -276,6 +276,7 @@ module.exports = Hub = ->
 
       err = new Error 'ETIMEDOUT'
       err.code = 'ETIMEDOUT'
+      err.completion = true
       err.message = "Response timed out after #{completionTimeoutInterval}ms"
       err.responseData = responseData
       req.emit 'error', err

--- a/test/hub/_test_server.coffee
+++ b/test/hub/_test_server.coffee
@@ -27,6 +27,17 @@ buildApp = ->
         res.end "ok"
       ), req.query.__delay
 
+    else if req.query.__chunkDelay && req.query.__totalDelay
+      writeChunk = ->
+        res.write Array(4096+1).join 'a'
+      writeChunkHandle = setInterval writeChunk, +req.query.__chunkDelay
+
+      finishRes = ->
+        clearInterval writeChunkHandle
+        res.end 'ok'
+
+      setTimeout finishRes, +req.query.__totalDelay
+
     else
       res.end "ok"
 


### PR DESCRIPTION
This makes sure that `completionTimeout` does in fact catch some issues that the `timeout` setting misses.