### PR TITLE
Port better timeout handling from 2.x

### DIFF
--- a/lib/fetch.js
+++ b/lib/fetch.js
@@ -236,6 +236,7 @@ function _fetch(urlObj, options) {
     body: body,
     connectTimeout: defaultTimeout(options.connectTimeout, DEFAULT_CONNECT_TIMEOUT),
     timeout: defaultTimeout(options.timeout, DEFAULT_TIMEOUT),
+    completionTimeout: defaultTimeout(options.completionTimeout, 0),
     minStatusCode: defaultStatusCode(options.minStatusCode, 200),
     maxStatusCode: defaultStatusCode(options.maxStatusCode, 299),
     // Some things we might want to expose for instrumentation to pick up:

--- a/lib/request.js
+++ b/lib/request.js
@@ -41,6 +41,49 @@ var debug = require('debug')('gofer');
 var StatusCodeError = require('./errors').StatusCodeError;
 var resProperties = require('./response');
 
+function noop() {}
+
+function clearImmediateSafe(handle) {
+  // See: https://github.com/nodejs/node/pull/9759
+  if (!handle) return;
+  clearImmediate(handle);
+  handle._onImmediate = noop;
+}
+
+function setIOTimeout(callback, ms) {
+  var initialHandle = null;
+  var delayHandle = null;
+  var done = false;
+  function onDelay() {
+    if (done) return;
+    done = true;
+    delayHandle = null;
+    callback();
+  }
+  function onTimer() {
+    if (done) return;
+    initialHandle = null;
+    delayHandle = setImmediate(onDelay);
+  }
+  function cancel() {
+    if (done) return;
+    done = true;
+    clearTimeout(initialHandle);
+    clearImmediateSafe(delayHandle);
+    initialHandle = delayHandle = null;
+    return;
+  }
+  initialHandle = setTimeout(onTimer, ms);
+  return cancel;
+}
+
+function clearIOTimeout(handle) {
+  if (!handle) {
+    return undefined;
+  }
+  return handle();
+}
+
 function _callJSON(res) {
   return res.json();
 }
@@ -61,8 +104,6 @@ function parseErrorBody(rawBody) {
     return source;
   }
 }
-
-function noop() {}
 
 var reqProperties = {
   json: {
@@ -106,6 +147,8 @@ function request_(options, resolve, reject) {
   var res_ = null;
   var connectTimer = null;
   var responseTimer = null;
+  var completionTimer = null;
+  var socketTimer = null;
 
   var startTime = Date.now();
   var timing = {
@@ -116,10 +159,14 @@ function request_(options, resolve, reject) {
 
   function failAndAbort(error) {
     debug('<- %s %s', error.code || error.statusCode, fullUrl);
-    clearTimeout(connectTimer);
+    clearIOTimeout(connectTimer);
     connectTimer = null;
-    clearTimeout(responseTimer);
+    clearIOTimeout(responseTimer);
     responseTimer = null;
+    clearIOTimeout(completionTimer);
+    completionTimer = null;
+    clearImmediateSafe(socketTimer);
+    socketTimer = null;
 
     if (req_ !== null) {
       req_.abort();
@@ -131,7 +178,7 @@ function request_(options, resolve, reject) {
   function emitError(error) {
     if (res_) {
       res_.emit('error', error);
-    } else {
+    } else if (req_) {
       req_.emit('error', error);
     }
   }
@@ -157,7 +204,7 @@ function request_(options, resolve, reject) {
   }
 
   function handleResponse(res) {
-    clearTimeout(responseTimer);
+    clearIOTimeout(responseTimer);
     responseTimer = null;
 
     timing.headers = Date.now() - startTime;
@@ -174,11 +221,26 @@ function request_(options, resolve, reject) {
     }
   }
 
-  function onResponseTimedOut() {
-    var error = new Error('Fetching from ' + host + ' timed out');
+  function isConnecting() {
+    return !!(req_ && req_.socket && req_.socket.readable === false);
+  }
+
+  function onCompletionTimedOut() {
+    var error = new Error('Request to ' + host + ' timed out');
     error.code = 'ETIMEDOUT';
+    error.timeout = options.completionTimeout;
+    error.timing = timing;
+    error.connect = isConnecting();
+    error.completion = true;
+    emitError(error);
+  }
+
+  function onResponseTimedOut(code) {
+    var error = new Error('Fetching from ' + host + ' timed out');
+    error.code = code || 'ETIMEDOUT';
     error.timeout = options.timeout;
     error.timing = timing;
+    error.connect = isConnecting();
     emitError(error);
   }
 
@@ -187,26 +249,40 @@ function request_(options, resolve, reject) {
     error.code = 'ECONNECTTIMEDOUT';
     error.connectTimeout = options.connectTimeout;
     error.timing = timing;
+    error.connect = true;
     emitError(error);
   }
 
   function onConnect() {
     timing.connect = Date.now() - startTime;
-    clearTimeout(connectTimer);
+    clearIOTimeout(connectTimer);
     connectTimer = null;
+  }
+
+  function onSocketTimeout() {
+    socketTimer = setImmediate(function checkRealTimeout() {
+      socketTimer = null;
+      if (req_ && req_.socket && req_.socket.readable) {
+        onResponseTimedOut('ESOCKETTIMEDOUT');
+      }
+    });
   }
 
   function onSocket(socket) {
     timing.socket = Date.now() - startTime;
-    connectTimer = setTimeout(onConnectTimedOut, options.connectTimeout);
+    connectTimer = setIOTimeout(onConnectTimedOut, options.connectTimeout);
     socket.once('connect', onConnect);
 
-    responseTimer = setTimeout(onResponseTimedOut, options.timeout);
-    socket.setTimeout(options.timeout, onResponseTimedOut);
+    responseTimer = setIOTimeout(onResponseTimedOut, options.timeout);
+    socket.setTimeout(options.timeout, onSocketTimeout);
   }
 
   function onRequest(req) {
     req_ = req;
+
+    if (options.completionTimeout > 0) {
+      setIOTimeout(onCompletionTimedOut, options.completionTimeout);
+    }
 
     req.once('response', handleResponse);
     req.on('error', failAndAbort);

--- a/test/_remote-server
+++ b/test/_remote-server
@@ -1,0 +1,43 @@
+#!/usr/bin/env node
+'use strict';
+var childProcess = require('child_process');
+var http = require('http');
+
+var SERVER_LISTEN = 'gofer-server-listen';
+
+var child;
+var server;
+
+exports.port = null;
+
+exports.fork = function fork(done) {
+  child = childProcess.fork(__filename);
+  child.on('message', function onChildMessage(message) {
+    if (message.kind === SERVER_LISTEN) {
+      exports.port = message.port;
+      done();
+    } else {
+      console.error(message);
+    }
+  });
+};
+
+exports.kill = function kill(done) {
+  child.kill();
+  done();
+};
+
+if (module === process.mainModule) {
+  server = http.createServer(function onRequest(req, res) {
+    setTimeout(function () {
+      res.writeHead(200);
+      setTimeout(function () {
+        res.end('ok');
+      }, 50);
+    }, 50);
+  });
+
+  server.listen(0, function onListen() {
+    process.send({ kind: SERVER_LISTEN, port: server.address().port });
+  });
+}


### PR DESCRIPTION
1. Use `setIOTimeout` (delay timeout firing to work around event loop lag)
2. Add `completionTimeout` support

See: https://github.com/groupon/gofer/pull/72
See: https://github.com/groupon/gofer/pull/71