### PR TITLE
Move 2.x to stable

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,10 @@
     "watch": "coffee --no-header -wcbo lib src & nodemon -w lib -w test -e coffee,js,json -x \"mocha\""
   },
   "nlm": {
+    "channels": {
+      "2.x": "stable",
+      "master": "latest"
+    },
     "license": {
       "files": [
         "src"


### PR DESCRIPTION
This prepares moving gofer 3 to `master`/`latest`.

* Created branch `2.x`.
* Updated channels so that we can still release fixes for gofer 2.