### PR TITLE
support `keepAlive: true` option

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,12 @@
 language: node_js
 node_js:
-  - '0.10'
   - '4'
-before_install:
-  - npm install -g npm@latest-2
-before_deploy:
-  - 'git config --global user.email "opensource@groupon.com"'
-  - 'git config --global user.name "Groupon"'
+  - '6'
+  - '8'
 deploy:
   provider: script
   script: ./node_modules/.bin/nlm release
   skip_cleanup: true
   'on':
     branch: 2.x
-    node: '4'
+    node: '8'

--- a/API.md
+++ b/API.md
@@ -197,6 +197,8 @@ In addition to the options mentioned in the [request docs](https://github.com/mi
 * `searchDomain`: Inspired by the `search` setting in `/etc/resolv.conf`.
   Append this to any hostname that doesn't already end in a ".".
   E.g. `my-hostname` turns into `my-hostname.<searchDomain>.` but `my.fully.qualified.name.` won't be touched.
+* `keepAlive`: If set to `true`, enables the request `forever` option and does
+  not send the `Connection: close` header
 
 In addition the following options are added that are useful for instrumentation but do not affect the actual HTTP request:
 

--- a/lib/hub.js
+++ b/lib/hub.js
@@ -122,7 +122,8 @@ module.exports = Hub = function() {
       options.headers = {};
     }
     options.method = options.method != null ? options.method.toUpperCase() : 'GET';
-    hubHeaders = generateHeaders(options.requestId, fetchId);
+    options.forever = options.keepAlive;
+    hubHeaders = generateHeaders(options.requestId, fetchId, options.keepAlive);
     extend(options.headers, hubHeaders);
     options.headers = mapValues(options.headers, removeInvalidHeaderChars);
     logPendingRequests(http.globalAgent);
@@ -321,12 +322,14 @@ generateUUID = function() {
   return uuid.v1().replace(/-/g, '');
 };
 
-generateHeaders = function(requestId, fetchId) {
+generateHeaders = function(requestId, fetchId, keepAlive) {
   var headers;
   headers = {
-    'Connection': 'close',
     'X-Fetch-ID': fetchId
   };
+  if (!keepAlive) {
+    headers.Connection = 'close';
+  }
   if (requestId != null) {
     headers['X-Request-ID'] = requestId;
   }

--- a/src/hub.coffee
+++ b/src/hub.coffee
@@ -111,7 +111,8 @@ module.exports = Hub = ->
       options.method.toUpperCase()
     else
       'GET'
-    hubHeaders = generateHeaders options.requestId, fetchId
+    options.forever = options.keepAlive
+    hubHeaders = generateHeaders options.requestId, fetchId, options.keepAlive
     extend options.headers, hubHeaders
     options.headers = mapValues options.headers, removeInvalidHeaderChars
 
@@ -295,10 +296,9 @@ module.exports = Hub = ->
 generateUUID = ->
   uuid.v1().replace /-/g, ''
 
-generateHeaders = (requestId, fetchId) ->
-  headers =
-    'Connection': 'close'
-    'X-Fetch-ID': fetchId
+generateHeaders = (requestId, fetchId, keepAlive) ->
+  headers = 'X-Fetch-ID': fetchId
+  headers.Connection = 'close' unless keepAlive
 
   headers['X-Request-ID'] = requestId if requestId?
   headers


### PR DESCRIPTION
Just setting `forever: true` as a pass-thru to request (a) didn't work
because we were forcing `Connection: close` and (b) isn't
forward-compatible with Gofer 3.x
