### PR TITLE
use proper timeout to fix keepAlive

### DIFF
--- a/API.md
+++ b/API.md
@@ -31,6 +31,7 @@ import { fetch } from 'gofer';
 * `searchDomain`: Inspired by the `search` setting in `/etc/resolv.conf`.
   Append this to any hostname that doesn't already end in a ".".
   E.g. `my-hostname` turns into `my-hostname.<searchDomain>.` but `my.fully.qualified.name.` won't be touched.
+* `keepAlive`: if set to `true`, enables HTTP keep-alive
 
 ## `Gofer`
 

--- a/lib/request.js
+++ b/lib/request.js
@@ -266,7 +266,7 @@ function requestFunc(options, resolve, reject) {
     connectTimer = null;
   }
 
-  function onSocketTimeout() {
+  function onSocketTimedOut() {
     socketTimer = setImmediate(function checkRealTimeout() {
       socketTimer = null;
       if (reqObj && reqObj.socket && reqObj.socket.readable) {
@@ -281,7 +281,6 @@ function requestFunc(options, resolve, reject) {
     socket.once('connect', onConnect);
 
     responseTimer = setIOTimeout(onResponseTimedOut, options.timeout);
-    socket.setTimeout(options.timeout, onSocketTimeout);
   }
 
   function onRequest(req) {
@@ -290,6 +289,8 @@ function requestFunc(options, resolve, reject) {
     if (options.completionTimeout > 0) {
       setIOTimeout(onCompletionTimedOut, options.completionTimeout);
     }
+
+    req.setTimeout(options.timeout, onSocketTimedOut);
 
     req.once('response', handleResponse);
     req.on('error', failAndAbort);


### PR DESCRIPTION
`req.setTimeout()` achieves the same thing we were going for with
`socket.setTimeout()` but also cleans itself up, thus preserving
keepalive behavior (and not closing the socket between requests)
