### PR TITLE
clear completionTimer on response completion

### DIFF
--- a/lib/request.js
+++ b/lib/request.js
@@ -159,14 +159,18 @@ function requestFunc(options, resolve, reject) {
     headers: null,
   };
 
+  function clearCompletionTimer() {
+    clearIOTimeout(completionTimer);
+    completionTimer = null;
+  }
+
   function failAndAbort(error) {
     debug('<- %s %s', error.code || error.statusCode, fullUrl);
     clearIOTimeout(connectTimer);
     connectTimer = null;
     clearIOTimeout(responseTimer);
     responseTimer = null;
-    clearIOTimeout(completionTimer);
-    completionTimer = null;
+    clearCompletionTimer();
     clearImmediateSafe(socketTimer);
     socketTimer = null;
 
@@ -219,6 +223,7 @@ function requestFunc(options, resolve, reject) {
     resObj = Object.defineProperties(res, resProperties);
     resObj.url = fullUrl;
     resObj.on('error', failAndAbort);
+    resObj.on('end', clearCompletionTimer);
 
     if (!isAcceptableStatus(res.statusCode)) {
       generateStatusCodeError();
@@ -287,7 +292,10 @@ function requestFunc(options, resolve, reject) {
     reqObj = req;
 
     if (options.completionTimeout > 0) {
-      setIOTimeout(onCompletionTimedOut, options.completionTimeout);
+      completionTimer = setIOTimeout(
+        onCompletionTimedOut,
+        options.completionTimeout
+      );
     }
 
     req.setTimeout(options.timeout, onSocketTimedOut);


### PR DESCRIPTION
It was breaking `keepAlive` before this.