### PR TITLE
don't set connect timeout for keepalive

### DIFF
--- a/lib/request.js
+++ b/lib/request.js
@@ -282,8 +282,11 @@ function requestFunc(options, resolve, reject) {
 
   function onSocket(socket) {
     timing.socket = Date.now() - startTime;
-    connectTimer = setIOTimeout(onConnectTimedOut, options.connectTimeout);
-    socket.once('connect', onConnect);
+
+    if (socket._connecting || socket.connecting) {
+      connectTimer = setIOTimeout(onConnectTimedOut, options.connectTimeout);
+      socket.once('connect', onConnect);
+    }
 
     responseTimer = setIOTimeout(onResponseTimedOut, options.timeout);
   }


### PR DESCRIPTION
If you have an existing socket from a KeepAlive connection, the
`connect` event will never be fired, which causes the timeout to fire,
which was closing the KeepAlive'd connection

See: https://github.com/request/request/blob/a6741d415aba31cd01e9c4544c96f84ea6ed11e3/request.js#L778-L779