### PR TITLE
enable gzip support by default

### DIFF
--- a/lib/hub.js
+++ b/lib/hub.js
@@ -118,6 +118,9 @@ module.exports = Hub = function() {
     headerTimeoutInterval = checkTimeout((ref3 = options.timeout) != null ? ref3 : Hub.requestTimeout);
     delete options.timeout;
     connectTimeoutInterval = checkTimeout((ref4 = options.connectTimeout) != null ? ref4 : Hub.connectTimeout);
+    if (options.gzip == null) {
+      options.gzip = true;
+    }
     if (options.headers == null) {
       options.headers = {};
     }

--- a/src/hub.coffee
+++ b/src/hub.coffee
@@ -106,6 +106,7 @@ module.exports = Hub = ->
     delete options.timeout
     connectTimeoutInterval = checkTimeout options.connectTimeout ? Hub.connectTimeout
 
+    options.gzip ?= true
     options.headers ?= {}
     options.method = if options.method?
       options.method.toUpperCase()


### PR DESCRIPTION
Default gzip Accept-Encoding and handling behavior to `true` if not
otherwise specified

Works around issue seen with some API servers.