### PR TITLE
support `fetch().stream().then()`

### DIFF
--- a/API.md
+++ b/API.md
@@ -51,6 +51,35 @@ import { fetch } from 'gofer';
 [basicauth]: https://en.wikipedia.org/wiki/Basic_access_authentication
 [tls]: https://nodejs.org/api/tls.html#tls_new_tls_tlssocket_socket_options
 
+### Return/callback value
+
+`fetch()` returns a Promise for, or calls the callback specified with a
+response object, which supports the following methods.  For convenience
+in Promise mode, you may also invoke each of them directly on the Promise
+returned from `fetch()`, i.e. you may do:
+
+```js
+fetch(url).then(res => res.json()).then(obj => console.log(obj.status));
+// OR
+fetch(url).json().then(obj => console.log(obj.status));
+```
+
+#### `.json() => Promise<Object>`
+
+Returns a Promise for the entire response text, parsed as JSON
+
+#### `.text() => Promise<string>`
+
+Returns a Promise for the entire response, charset decoded
+
+#### `.rawBody() => Promise<buffer>`
+
+Returns a Promise for the raw response body, as a Buffer
+
+#### `.stream() => ReadableStream`
+
+Returns a stream for the data as it arrives
+
 ## `Gofer`
 
 This class can be used directly

--- a/API.md
+++ b/API.md
@@ -16,22 +16,40 @@ import { fetch } from 'gofer';
 ### Options
 
 * `method`: The HTTP verb, e.g. 'GET' or 'POST'.
-* `headers`: A plain object with header names and values. E.g. `{'content-type': 'text/x-cats'}`.
-* `auth`: Either a string of the form `username:password` or an object with `username` and `password` properties that will be used to generate a [basic authorization header](https://en.wikipedia.org/wiki/Basic_access_authentication).
-* `baseUrl`: Prefix for the `url` parameter. `fetch('/echo', { baseUrl: 'https://my-api.com/v2' })` will load https://my-api.com/v2/echo.
-* `pathParams`: Values for placeholders in the url path. E.g. `{ foo: 'bar' }` will replace all occurrences of `{foo}` in the url path with `'bar'`.
-* `qs`: Additional query parameters that will be serialized using the [`qs` library](https://www.npmjs.com/package/qs).
-* `body`: Content of the request body, either as a string, a Buffer, or a readable stream.
+* `headers`: A plain object with header names and values. E.g.
+    `{'content-type': 'text/x-cats'}`.
+* `auth`: Either a string of the form `username:password` or an object with
+    `username` and `password` properties that will be used to generate a
+    [basic authorizationheader][basicauth].
+* `baseUrl`: Prefix for the `url` parameter.
+    `fetch('/echo', { baseUrl: 'https://my-api.com/v2' })` will load
+    https://my-api.com/v2/echo.
+* `pathParams`: Values for placeholders in the url path. E.g. `{ foo: 'bar' }`
+    will replace all occurrences of `{foo}` in the url path with `'bar'`.
+* `qs`: Additional query parameters that will be serialized using the
+    [`qs` library](https://www.npmjs.com/package/qs).
+* `body`: Content of the request body, either as a string, a Buffer, or a
+    readable stream.
 * `json`: Content of the request body to be sent as a JSON encoded value.
-* `form`: Content of the request body to be sent using `x-www-form-urlencoded`. The serialization is handled by the [`qs` library](https://www.npmjs.com/package/qs).
-* All [TLS socket options](https://nodejs.org/api/tls.html#tls_new_tls_tlssocket_socket_options) for https requests.
-* `maxSockets`: Maximum number of parallel requests to the same domain. `gofer` will never use the global http(s) agent but will instead keep agents per client class.
+* `form`: Content of the request body to be sent using `x-www-form-urlencoded`.
+    The serialization is handled by the
+    [`qs` library](https://www.npmjs.com/package/qs).
+* All [TLS socket options][tls] for https requests.
+* `maxSockets`: Maximum number of parallel requests to the same domain. `gofer`
+    will never use the global http(s) agent but will instead keep agents per
+    client class.
 * `timeout`: Response- and socket read timeout in milliseconds.
-* `connectTimeout`: Timeout in milliseconds for the time between acquiring a socket and establishing a connection to the remote host. This should generally be relatively low.
+* `connectTimeout`: Timeout in milliseconds for the time between acquiring a
+    socket and establishing a connection to the remote host. This should
+    generally be relatively low.
 * `searchDomain`: Inspired by the `search` setting in `/etc/resolv.conf`.
-  Append this to any hostname that doesn't already end in a ".".
-  E.g. `my-hostname` turns into `my-hostname.<searchDomain>.` but `my.fully.qualified.name.` won't be touched.
+    Append this to any hostname that doesn't already end in a ".".
+    E.g. `my-hostname` turns into `my-hostname.<searchDomain>.` but
+    `my.fully.qualified.name.` won't be touched.
 * `keepAlive`: if set to `true`, enables HTTP keep-alive
+
+[basicauth]: https://en.wikipedia.org/wiki/Basic_access_authentication
+[tls]: https://nodejs.org/api/tls.html#tls_new_tls_tlssocket_socket_options
 
 ## `Gofer`
 
@@ -75,10 +93,12 @@ There are three levels of configuration:
 
 * `config.globalDefaults`: Applies for calls to all services.
 * `config[serviceName]`: Only applies to calls to one specific service.
-* `config[serviceName].endpointDefaults[endpointName]`: Only applies to calls using a specific endpoint.
+* `config[serviceName].endpointDefaults[endpointName]`: Only applies to calls
+    using a specific endpoint.
 
-More specific configuration wins,
-e.g. an endpoint-level default takes precendence over a service-level default.
+More specific configuration wins, e.g. an endpoint-level default takes
+precendence over a service-level default.
+
 Example:
 
 ```js
@@ -117,20 +137,27 @@ b.x(); // will use timeout: 23, connectTimeout: 70
 #### Option mappers
 
 All service-specific behavior is implemented using option mappers.
-Whenever an request is made, either via an endpoint or directly via `gofer.fetch`,
-the options go through the following steps:
+Whenever an request is made, either via an endpoint or directly via
+`gofer.fetch`, the options go through the following steps:
 
-1. The endpoint defaults are applied if the request was made through an endpoint.
+1. The endpoint defaults are applied if the request was made through an
+    endpoint.
 3. `options.serviceName` and `options.serviceVersion` is added.
-4. `options.methodName` and `options.endpointName` is added. The former defaults to the http verb but can be set to a custom value (e.g. `addFriend`). The latter is only set if the request was made through an endpoint method.
+4. `options.methodName` and `options.endpointName` is added. The former
+    defaults to the http verb but can be set to a custom value (e.g.
+    `addFriend`). The latter is only set if the request was made through an
+    endpoint method.
 5. The service-specific and global defaults are applied.
-6. For every registered option mapper `m` the `options` are set to `m(options) || options`.
+6. For every registered option mapper `m` the `options` are set to
+    `m(options) || options`.
 7. A `User-Agent` header is added if not present already.
-8. `null` and `undefined` values are removed from `qs` and `headers`. If you want to pass empty values, you should use an empty string.
+8. `null` and `undefined` values are removed from `qs` and `headers`. If you
+    want to pass empty values, you should use an empty string.
 
-Step 6 implies that every option mapper is a function that takes one argument `options` and returns transformed options or a falsy value.
-Inside of the mapper `this` refers to the `gofer` instance.
-The example contains an option mapper that handles access tokens and a default base url.
+Step 6 implies that every option mapper is a function that takes one argument
+`options` and returns transformed options or a falsy value. Inside of the
+mapper `this` refers to the `gofer` instance. The example contains an option
+mapper that handles access tokens and a default base url.
 
 ### Methods modifying the prototype
 
@@ -150,10 +177,11 @@ The following conditions are to be met by `endpointMap`:
 
 1. It maps a string identifier that is a valid property name to a function.
 2. The function takes one argument which is `fetch`.
-3. `fetch` works like `gofer.fetch` only that it's aware of [endpoint defaults](#configuration).
+3. `fetch` works like `gofer.fetch` only that it's aware of
+    [endpoint defaults](#configuration).
 
-Whatever the function returns will be available as a property on instances of the class.
-Common variants are a function or a nested objects with functions.
+Whatever the function returns will be available as a property on instances of
+the class. Common variants are a function or a nested objects with functions.
 
 ```js
 MyService.prototype.registerEndpoints({
@@ -183,7 +211,8 @@ my.complex.bar({ name: 'Jordan', friends: 231 }, function(err, body) {});
 
 #### `gofer.clone()`
 
-Creates a new instance with the exact same settings and referring to the same `hub`.
+Creates a new instance with the exact same settings and referring to the same
+`hub`.
 
 #### `gofer.with(overrideConfig)`
 
@@ -215,20 +244,23 @@ the error will be a `StatusCodeError` with the following properties:
 * `minStatusCode`: The lower bound of accepted status codes.
 * `maxStatusCode`: The upper bound of accepted status codes.
 
-The accepted range of status codes is part of the [configuration](#configuration).
-It defaults to accepting 2xx codes only.
+The accepted range of status codes is part of the
+[configuration](#configuration). It defaults to accepting 2xx codes only.
 
 If there's an error that prevents any response from being returned,
-you can look for `code` to find out what happened.
-Possible values include:
+you can look for `code` to find out what happened. Possible values include:
 
-* `ECONNECTTIMEDOUT`: It took longer than `options.connectTimeout` allowed to establish a connection.
+* `ECONNECTTIMEDOUT`: It took longer than `options.connectTimeout` allowed to
+    establish a connection.
 * `ETIMEDOUT`: Request took longer than `options.timeout` allowed.
-* `ESOCKETTIMEDOUT`: Same as `ETIMEDOUT` but signifies that headers were received.
+* `ESOCKETTIMEDOUT`: Same as `ETIMEDOUT` but signifies that headers were
+    received.
 * `EPIPE`: Writing to the request failed.
-* `ECONNREFUSED`: The remote host refused the connection, e.g. because nothing was listening on the port.
+* `ECONNREFUSED`: The remote host refused the connection, e.g. because nothing
+    was listening on the port.
 * `ENOTFOUND`: The hostname failed to resolve.
-* `ECONNRESET`: The remote host dropped the connection. E.g. you are talking to another node based service and a process died.
+* `ECONNRESET`: The remote host dropped the connection. E.g. you are talking
+    to another node based service and a process died.
 
 ### Instance properties
 

--- a/lib/request.js
+++ b/lib/request.js
@@ -98,6 +98,10 @@ function callRawBody(res) {
   return res.rawBody();
 }
 
+function callStream(res) {
+  return res.stream();
+}
+
 function parseErrorBody(rawBody) {
   var source = rawBody.toString();
   try {
@@ -123,6 +127,12 @@ var reqProperties = {
   rawBody: {
     value: function rawBody() {
       return this.then(callRawBody);
+    },
+  },
+
+  stream: {
+    value: function stream() {
+      return this.then(callStream);
     },
   },
 };
@@ -283,6 +293,7 @@ function requestFunc(options, resolve, reject) {
   function onSocket(socket) {
     timing.socket = Date.now() - startTime;
 
+    // eslint-disable-next-line no-underscore-dangle
     if (socket._connecting || socket.connecting) {
       connectTimer = setIOTimeout(onConnectTimedOut, options.connectTimeout);
       socket.once('connect', onConnect);


### PR DESCRIPTION
* feat: support `fetch().stream().then()`
* docs: wrap API docs @ 80 columns
* docs: `.json()`, `.text()`, etc.