### PR TITLE
Add gofer.getMergedOptions

### DIFF
--- a/lib/gofer.js
+++ b/lib/gofer.js
@@ -105,6 +105,15 @@ function preventComplexMerge(objValue, srcValue) {
 
 // eslint-disable-next-line no-underscore-dangle
 Gofer.prototype._prepareOptions = function _prepareOptions(defaults, options) {
+  return this.getMergedOptions(defaults, options);
+};
+
+Gofer.prototype.getMergedOptions = function getMergedOptions(
+  defaults,
+  options
+) {
+  defaults = defaults || {};
+  options = options || {};
   var endpointName = options.endpointName || defaults.endpointName;
   var mergedOptions = mergeWith(
     {},
@@ -114,13 +123,14 @@ Gofer.prototype._prepareOptions = function _prepareOptions(defaults, options) {
     options,
     preventComplexMerge
   );
+  delete mergedOptions.endpointDefaults;
   return this._mappers.reduce(applyOptionMapper, mergedOptions);
 };
 
 function fetchWithDefaults(defaults) {
   return function withDefaults(uri, options, callback) {
     options = options || {};
-    return fetch(uri, this._prepareOptions(defaults, options), callback);
+    return fetch(uri, this.getMergedOptions(defaults, options), callback);
   };
 }
 

--- a/test/gofer.test.js
+++ b/test/gofer.test.js
@@ -3,6 +3,7 @@
 'use strict';
 
 var assert = require('assertive');
+var assign = require('lodash/assign');
 
 var Gofer = require('../');
 
@@ -26,6 +27,31 @@ describe('gofer', function() {
     it('can fetch something', function() {
       return gofer.get('/echo');
     });
+  });
+
+  describe('allows getting merged options', function() {
+    var gofer = new Gofer({}, 'my-service', '1.2.3', 'my-client').with(options);
+    assert.deepEqual(
+      assign({}, options, {
+        clientName: 'my-client',
+        clientVersion: '1.2.3',
+        serviceName: 'my-service',
+      }),
+      gofer.getMergedOptions()
+    );
+
+    assert.deepEqual(
+      assign({}, options, {
+        customOption: 42,
+        clientName: 'different-client',
+        clientVersion: '1.2.3',
+        serviceName: 'my-service',
+      }),
+      gofer.getMergedOptions({
+        customOption: 42,
+        clientName: 'different-client',
+      })
+    );
   });
 
   describe('call that sets a header', function() {


### PR DESCRIPTION
This adds an official way to get the effective options, given some defaults and/or overrides.