### PR TITLE
various type declaration fixes

### DIFF
--- a/lib/typedefs.d.ts
+++ b/lib/typedefs.d.ts
@@ -1,5 +1,5 @@
-import { SecureContext } from "tls";
-import { ServerResponse } from "http";
+import { SecureContext } from 'tls';
+import { ServerResponse } from 'http';
 
 type BodyMethods = {
   json(): Promise<any>;
@@ -19,10 +19,14 @@ declare class Gofer {
   );
 
   addOptionMapper(mapper: (opts: Gofer.Opts) => Gofer.Opts): void;
+  getMergedOptions(
+    defaults?: Gofer.FetchOpts,
+    options?: Gofer.FetchOpts
+  ): Gofer.FetchOpts;
 
-  clone(): Gofer;
+  clone(): this;
 
-  with(opts: Gofer.Opts): Gofer;
+  with(opts: Gofer.Opts): this;
 
   fetch(path: string, opts?: Gofer.FetchOpts): FetchResponse;
   get(path: string, opts?: Gofer.FetchOpts): FetchResponse;
@@ -53,12 +57,13 @@ declare namespace Gofer {
     maxStatusCode?: number;
     rejectUnauthorized?: boolean;
     secureContext?: SecureContext;
+    [opt: string]: any;
   };
 
   export type FetchOpts = Opts & {
-    endpointName: string;
+    endpointName?: string;
     json?: object;
-    method?: "GET" | "PUT" | "POST" | "DELETE" | "PATCH" | "HEAD" | "OPTIONS";
+    method?: 'GET' | 'PUT' | 'POST' | 'DELETE' | 'PATCH' | 'HEAD' | 'OPTIONS';
     body?: string | Buffer | ReadableStream;
     form?: { [name: string]: any };
   };


### PR DESCRIPTION
* `clone()` and `with()` now return `this` type
* type sig added for `getMergedOptions()`
* made `endpointName` optional in FetchOpts
* make Opts more open to allow for custom opts
* run typedefs thru prettier --single-quote

Fixes: https://github.com/groupon/gofer/issues/104
Fixes: https://github.com/groupon/gofer/issues/105


---
_This PR was started by: [git wf pr](https://github.com/groupon/git-workflow/releases/tag/v1.0.3)_