### PR TITLE
optional path params

### DIFF
--- a/lib/typedefs.d.ts
+++ b/lib/typedefs.d.ts
@@ -42,10 +42,13 @@ declare class Gofer {
 }
 
 declare namespace Gofer {
-  export function fetch(path: string, opts?: Gofer.FetchOpts): FetchResponse;
+  export function fetch(
+    path: string,
+    opts?: Gofer.FetchOpts & { pathParams?: { [param: string]: string } }
+  ): FetchResponse;
 
   export type Opts = {
-    pathParams?: { [param: string]: string };
+    pathParams?: { [param: string]: string | undefined };
     timeout?: number;
     connectTimeout?: number;
     searchDomain?: string;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1402,7 +1402,7 @@
     },
     "es6-promisify": {
       "version": "5.0.0",
-      "resolved": "http://registry.npmjs.org/es6-promisify/-/es6-promisify-5.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/es6-promisify/-/es6-promisify-5.0.0.tgz",
       "integrity": "sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=",
       "dev": true,
       "requires": {
@@ -2833,9 +2833,9 @@
       "dev": true
     },
     "https-proxy-agent": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-2.2.2.tgz",
-      "integrity": "sha512-c8Ndjc9Bkpfx/vCJueCPy0jlP4ccCCSNDp8xwCZzPjKJUm+B+u9WX2x98Qx4n1PiMNTWo3D7KK5ifNV/yJyRzg==",
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-2.2.3.tgz",
+      "integrity": "sha512-Ytgnz23gm2DVftnzqRRz2dOXZbGd2uiajSw/95bPp6v53zPRspQjLm/AfBgqbJ2qfeRXWIOMVLpp86+/5yX39Q==",
       "dev": true,
       "requires": {
         "agent-base": "^4.3.0",


### PR DESCRIPTION
one might wish to write a client like this:

```js
class Foo extends Gofer {
  constructor(cfg) {
    super(cfg, 'foo');
  }

  bar({ x, y }) {
    return this.get('/{x}/{y}', {
      endpointName: 'bar',
      pathParams: { x, y },
    });
  }
}

const foo = new Foo({ foo: { pathParams: { x: 'whee' } } });
await foo.bar({ y: 'yay' });
```

with the current types, it will complain that you're passing an
undefined value as a pathParam, but really that will be dealt with in
the config merging later on, so we should accept it


---
_This PR was started by: [git wf pr](https://github.com/groupon/git-workflow/releases/tag/v1.0.3)_