### PR TITLE
correct the API docs regarding qs

### DIFF
--- a/API.md
+++ b/API.md
@@ -24,14 +24,14 @@ const { fetch } = require('gofer');
     https://my-api.com/v2/echo.
 * `pathParams`: Values for placeholders in the url path. E.g. `{ foo: 'bar' }`
     will replace all occurrences of `{foo}` in the url path with `'bar'`.
-* `qs`: Additional query parameters that will be serialized using the
+* `qs`: Additional query parameters that will be recursively serialized using
+    an algorithm similar to that of the
     [`qs` library](https://www.npmjs.com/package/qs).
 * `body`: Content of the request body, either as a string, a Buffer, or a
     readable stream.
 * `json`: Content of the request body to be sent as a JSON encoded value.
 * `form`: Content of the request body to be sent using `x-www-form-urlencoded`.
-    The serialization is handled by the
-    [`qs` library](https://www.npmjs.com/package/qs).
+    The serialization is the same as that used by the `qs` option.
 * All [TLS socket options][tls] for https requests.
 * `maxSockets`: Maximum number of parallel requests to the same domain. `gofer`
     will never use the global http(s) agent but will instead keep agents per

--- a/test/fetch-https.test.js
+++ b/test/fetch-https.test.js
@@ -12,7 +12,7 @@ describe('fetch: https', () => {
   it('can load from valid https remote', function() {
     // This is a remote call which isn't great but it means we get a valid
     // https certificate without having to pull any tricks.
-    this.timeout(2000);
+    this.timeout(10000);
     return fetch('https://api.reddit.com/user/ageitgey/about.json').json();
   });
 

--- a/test/fetch-timeout.test.js
+++ b/test/fetch-timeout.test.js
@@ -123,7 +123,9 @@ describe('fetch: timeouts', () => {
         .rejects(
           fetch('/', {
             baseUrl: options.baseUrl,
-            qs: { __delay: 50 },
+            qs: { __chunkDelay: 5, __totalDelay: 50 },
+            connectTimeout: 10,
+            timeout: 15,
             completionTimeout: 20,
           }).text()
         )


### PR DESCRIPTION
we no longer depend on the qs library itself


---
_This PR was started by: [git wf pr](https://github.com/groupon/git-workflow/releases/tag/v1.0.4)_