### PR TITLE
fix: guard asyncStack capturing with captureAsyncStack option

### DIFF
--- a/API.md
+++ b/API.md
@@ -56,6 +56,7 @@ const { fetch } = require('gofer');
     `my.fully.qualified.name.` won't be touched.
 * `keepAlive`: if set to `true`, enables HTTP keep-alive
   ⚠ Enabling `keepAlive` can lead to `MaxListenersExceededWarning: Possible EventEmitter memory leak detected.` warnings.
+* `captureAsyncStack`: Extends error trace with stack trace before call. (Default: `false`) **Capturing the stack is expensive! Set only for debugging purposes**
 
 [basicauth]: https://en.wikipedia.org/wiki/Basic_access_authentication
 [tls]: https://nodejs.org/api/tls.html#tls_new_tls_tlssocket_socket_options

--- a/lib/fetch.js
+++ b/lib/fetch.js
@@ -240,6 +240,7 @@ function fetchUrlObj(urlObj, options) {
     endpointName: options.endpointName,
     methodName: options.methodName || method.toLowerCase(),
     pathParams: options.pathParams,
+    captureAsyncStack: options.captureAsyncStack,
   });
 }
 

--- a/lib/request.js
+++ b/lib/request.js
@@ -148,13 +148,15 @@ function minTimeoutOf(options, higher, lower) {
   }
 }
 
-async function trackError(fn) {
-  const stack = new Error().stack;
+async function trackError(fn, opts) {
+  const stack = opts.captureAsyncStack ? new Error().stack : '';
 
   try {
     return await fn();
   } catch (e) {
-    e.stack = `${e.stack}\n${stack.substring(stack.indexOf('\n') + 1)}`;
+    if (stack) {
+      e.stack = `${e.stack}\n${stack.substring(stack.indexOf('\n') + 1)}`;
+    }
     throw e;
   }
 }
@@ -358,7 +360,10 @@ function requestFunc(options, resolve, reject) {
 }
 
 function request(options) {
-  const result = trackError(() => new Promise(requestFunc.bind(null, options)));
+  const result = trackError(
+    () => new Promise(requestFunc.bind(null, options)),
+    options
+  );
   return Object.defineProperties(result, reqProperties);
 }
 module.exports = request;

--- a/lib/typedefs.d.ts
+++ b/lib/typedefs.d.ts
@@ -62,6 +62,7 @@ declare namespace Gofer {
     maxStatusCode?: number;
     rejectUnauthorized?: boolean;
     secureContext?: SecureContext;
+    captureAsyncStack?: boolean;
     [opt: string]: any;
   };
 

--- a/test/fetch-http.test.js
+++ b/test/fetch-http.test.js
@@ -59,14 +59,18 @@ describe('fetch: the basics', () => {
       });
   });
 
-  it('extends async error stack with previous stack in error object ', function () {
+  it('when option "captureAsyncStack" is set, extends async error stack with previous stack in error object', function () {
     if (global.document) {
       this.skip();
     }
 
-    return assert.rejects(fetch('/json/404', options).json()).then(error => {
-      assert.include('at request', error.stack);
-    });
+    return assert
+      .rejects(
+        fetch('/json/404', { ...options, captureAsyncStack: true }).json()
+      )
+      .then(error => {
+        assert.include('at request', error.stack);
+      });
   });
 
   it('can add query string arguments', () => {


### PR DESCRIPTION
capturing the stack before a request is expensive. When needed, the option `captureAsyncStack` can be passed to debug a problem

- [x] fix: guard asyncStack capturing with captureAsyncStack option