### PR TITLE
type: json: object -> any

### DIFF
--- a/lib/typedefs.d.ts
+++ b/lib/typedefs.d.ts
@@ -15,8 +15,8 @@ type Fetch = (path: string, opts?: Gofer.FetchOpts, cb?: any) => FetchResponse;
 type EndpointFnReturn =
   | ((...args: any[]) => FetchResponse)
   | {
-      [key: string]: (...args: any[]) => FetchResponse;
-    };
+    [key: string]: (...args: any[]) => FetchResponse;
+  };
 
 export type EndpointFn = (fetch: Fetch) => EndpointFnReturn;
 
@@ -80,7 +80,7 @@ declare namespace Gofer {
 
   export type FetchOpts = Opts & {
     endpointName?: string;
-    json?: object;
+    json?: any;
     method?: 'GET' | 'PUT' | 'POST' | 'DELETE' | 'PATCH' | 'HEAD' | 'OPTIONS';
     body?: string | Buffer | ReadableStream;
     form?: { [name: string]: any };


### PR DESCRIPTION
One might have a REST API where you POST application/json that is just
the bytes `true` or some such.  In that case a body argument of type
boolean might be legitimate.



---
_This PR was started by: [git wf pr](https://github.com/groupon/git-workflow/releases/tag/v1.3.4)_