### PR TITLE
fix: merge URLSearchParams qs arguments

### DIFF
--- a/lib/gofer.js
+++ b/lib/gofer.js
@@ -32,11 +32,12 @@
 
 'use strict';
 
-const fetch = require('./fetch');
-
 const merge = require('lodash.merge');
 const mergeWith = require('lodash.mergewith');
 const isPlainObject = require('lodash.isplainobject');
+
+const fetch = require('./fetch');
+const { updateSearch } = require('./url');
 
 function Gofer(config, serviceName, clientVersion, clientName) {
   config = config || {};
@@ -99,12 +100,13 @@ function goferMerge(objValue, srcValue) {
     return DEFAULT_MERGER;
   }
 
-  // special case for merging qs config defaults with URLSearchParam fetch arg
-  if (isPlainObject(objValue) && srcValue instanceof URLSearchParams) {
-    const search = new URLSearchParams(objValue);
-    // using .set() instead of .append() because that seems more like "merging"
-    for (const [k, v] of srcValue) search.set(k, v);
-    return search;
+  if (
+    objValue instanceof URLSearchParams ||
+    srcValue instanceof URLSearchParams
+  ) {
+    const result = new URLSearchParams(objValue);
+    updateSearch(result, srcValue);
+    return result;
   }
 
   if (!isPlainObject(objValue) || !isPlainObject(srcValue)) {

--- a/lib/gofer.js
+++ b/lib/gofer.js
@@ -36,7 +36,6 @@ const fetch = require('./fetch');
 
 const merge = require('lodash.merge');
 const mergeWith = require('lodash.mergewith');
-const isObjectLike = require('lodash.isobjectlike');
 const isPlainObject = require('lodash.isplainobject');
 
 function Gofer(config, serviceName, clientVersion, clientName) {
@@ -89,8 +88,13 @@ function applyOptionMapper(options, mapper) {
   return mapper(options) || options;
 }
 
+// just like lodash
+function isObjectLike(obj) {
+  return typeof obj === 'object' && obj != null;
+}
+
 const DEFAULT_MERGER = undefined; // (see lodash/mergeWith docs)
-function preventComplexMerge(objValue, srcValue) {
+function goferMerge(objValue, srcValue) {
   if (!isObjectLike(objValue) && !isObjectLike(srcValue)) {
     return DEFAULT_MERGER;
   }
@@ -99,7 +103,7 @@ function preventComplexMerge(objValue, srcValue) {
     return srcValue || objValue;
   }
 
-  return mergeWith({}, objValue, srcValue, preventComplexMerge);
+  return mergeWith({}, objValue, srcValue, goferMerge);
 }
 
 // eslint-disable-next-line no-underscore-dangle
@@ -120,7 +124,7 @@ Gofer.prototype.getMergedOptions = function getMergedOptions(
     defaults,
     this.defaults.endpointDefaults[endpointName],
     options,
-    preventComplexMerge
+    goferMerge
   );
   delete mergedOptions.endpointDefaults;
   return this._mappers.reduce(applyOptionMapper, mergedOptions);

--- a/lib/gofer.js
+++ b/lib/gofer.js
@@ -99,6 +99,14 @@ function goferMerge(objValue, srcValue) {
     return DEFAULT_MERGER;
   }
 
+  // special case for merging qs config defaults with URLSearchParam fetch arg
+  if (isPlainObject(objValue) && srcValue instanceof URLSearchParams) {
+    const search = new URLSearchParams(objValue);
+    // using .set() instead of .append() because that seems more like "merging"
+    for (const [k, v] of srcValue) search.set(k, v);
+    return search;
+  }
+
   if (!isPlainObject(objValue) || !isPlainObject(srcValue)) {
     return srcValue || objValue;
   }

--- a/lib/url.js
+++ b/lib/url.js
@@ -39,8 +39,16 @@
  */
 function updateSearch(query, qs, path = []) {
   if (qs instanceof URLSearchParams) {
+    /** @type {Set<string>} */
+    const seenKey = new Set();
     for (const [key, val] of qs.entries()) {
-      query.append(key, val);
+      // rules for merging keys: all values for a given key in qs should
+      // replace all values for a given key in query
+      if (seenKey.has(key)) query.append(key, val);
+      else {
+        query.set(key, val);
+        seenKey.add(key);
+      }
     }
     return query;
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -4202,9 +4202,9 @@
       }
     },
     "node_modules/minimist": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
+      "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==",
       "dev": true
     },
     "node_modules/minimist-options": {
@@ -10186,9 +10186,9 @@
       }
     },
     "minimist": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
+      "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==",
       "dev": true
     },
     "minimist-options": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,7 @@
         "nlm": "^5.5.1",
         "npm-run-all": "^4.1.5",
         "prettier": "^2.3.2",
-        "self-signed": "^1.3.1",
+        "selfsigned": "^2.0.1",
         "semver": "^7.3.5"
       },
       "engines": {
@@ -4557,12 +4557,12 @@
       }
     },
     "node_modules/node-forge": {
-      "version": "0.2.37",
-      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.2.37.tgz",
-      "integrity": "sha1-JbfE03iGtSHqNehLZdtssIJHZFE=",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.3.1.tgz",
+      "integrity": "sha512-dPEtOeMvF9VMcYV/1Wb8CPoVAXtp6MKMlcbAt4ddqmGqUJ6fQZFXkNZNkNlfevtNkGtaSoXf/vNNNSvgrdXwtA==",
       "dev": true,
       "engines": {
-        "node": "*"
+        "node": ">= 6.13.0"
       }
     },
     "node_modules/normalize-package-data": {
@@ -5610,13 +5610,16 @@
         "node": "*"
       }
     },
-    "node_modules/self-signed": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/self-signed/-/self-signed-1.3.1.tgz",
-      "integrity": "sha1-JKY2Ot90rp7uwLz99uYOri64xQk=",
+    "node_modules/selfsigned": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/selfsigned/-/selfsigned-2.0.1.tgz",
+      "integrity": "sha512-LmME957M1zOsUhG+67rAjKfiWFox3SBxE/yymatMZsAx+oMrJ0YQ8AToOnyCm7xbeg2ep37IHLxdu0o2MavQOQ==",
       "dev": true,
       "dependencies": {
-        "node-forge": "~0.2.0"
+        "node-forge": "^1"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/semver": {
@@ -10453,9 +10456,9 @@
       }
     },
     "node-forge": {
-      "version": "0.2.37",
-      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.2.37.tgz",
-      "integrity": "sha1-JbfE03iGtSHqNehLZdtssIJHZFE=",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.3.1.tgz",
+      "integrity": "sha512-dPEtOeMvF9VMcYV/1Wb8CPoVAXtp6MKMlcbAt4ddqmGqUJ6fQZFXkNZNkNlfevtNkGtaSoXf/vNNNSvgrdXwtA==",
       "dev": true
     },
     "normalize-package-data": {
@@ -11264,13 +11267,13 @@
         "https-proxy-agent": "^2.2.1"
       }
     },
-    "self-signed": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/self-signed/-/self-signed-1.3.1.tgz",
-      "integrity": "sha1-JKY2Ot90rp7uwLz99uYOri64xQk=",
+    "selfsigned": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/selfsigned/-/selfsigned-2.0.1.tgz",
+      "integrity": "sha512-LmME957M1zOsUhG+67rAjKfiWFox3SBxE/yymatMZsAx+oMrJ0YQ8AToOnyCm7xbeg2ep37IHLxdu0o2MavQOQ==",
       "dev": true,
       "requires": {
-        "node-forge": "~0.2.0"
+        "node-forge": "^1"
       }
     },
     "semver": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,11 +6,10 @@
   "packages": {
     "": {
       "name": "gofer",
-      "version": "5.2.1",
+      "version": "5.2.3",
       "license": "BSD-3-Clause",
       "dependencies": {
         "debug": "^4.3.2",
-        "lodash.isobjectlike": "^4.0.0",
         "lodash.isplainobject": "^4.0.6",
         "lodash.merge": "^4.6.2",
         "lodash.mergewith": "^4.6.2"
@@ -3696,7 +3695,8 @@
     "node_modules/lodash.isobjectlike": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/lodash.isobjectlike/-/lodash.isobjectlike-4.0.0.tgz",
-      "integrity": "sha1-dCxfxlrdJ5JNPSQZFoGqmheytg0="
+      "integrity": "sha1-dCxfxlrdJ5JNPSQZFoGqmheytg0=",
+      "dev": true
     },
     "node_modules/lodash.isplainobject": {
       "version": "4.0.6",
@@ -9799,7 +9799,8 @@
     "lodash.isobjectlike": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/lodash.isobjectlike/-/lodash.isobjectlike-4.0.0.tgz",
-      "integrity": "sha1-dCxfxlrdJ5JNPSQZFoGqmheytg0="
+      "integrity": "sha1-dCxfxlrdJ5JNPSQZFoGqmheytg0=",
+      "dev": true
     },
     "lodash.isplainobject": {
       "version": "4.0.6",

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "nlm": "^5.5.1",
     "npm-run-all": "^4.1.5",
     "prettier": "^2.3.2",
-    "self-signed": "^1.3.1",
+    "selfsigned": "^2.0.1",
     "semver": "^7.3.5"
   },
   "author": {

--- a/package.json
+++ b/package.json
@@ -54,7 +54,6 @@
   "types": "lib/typedefs.d.ts",
   "dependencies": {
     "debug": "^4.3.2",
-    "lodash.isobjectlike": "^4.0.0",
     "lodash.isplainobject": "^4.0.6",
     "lodash.merge": "^4.6.2",
     "lodash.mergewith": "^4.6.2"

--- a/test/config.test.js
+++ b/test/config.test.js
@@ -112,4 +112,53 @@ describe('config handling', () => {
       ])
     );
   });
+
+  it('merges fetch-argument & config URLSearchParams', () => {
+    assert.deepStrictEqual(
+      a.getMergedOptions(
+        {
+          endpointName: 'x',
+          qs: new URLSearchParams([
+            ['key2', 'val2'],
+            ['key4', 'val4a'],
+            ['key4', 'val4b'],
+          ]),
+        },
+        {
+          qs: new URLSearchParams([
+            ['key3', 'val3'],
+            ['key4', 'val4'],
+          ]),
+        }
+      ).qs,
+      new URLSearchParams([
+        ['key2', 'val2'],
+        ['key4', 'val4'],
+        ['key3', 'val3'],
+      ])
+    );
+  });
+
+  it('merges fetch-argument qs obj with config URLSearchParams', () => {
+    assert.deepStrictEqual(
+      a.getMergedOptions(
+        {
+          endpointName: 'x',
+          qs: new URLSearchParams([
+            ['key2', 'val2'],
+            ['key4', 'val4a'],
+            ['key4', 'val4b'],
+          ]),
+        },
+        {
+          qs: { key2: 'val2b' },
+        }
+      ).qs,
+      new URLSearchParams([
+        ['key2', 'val2b'],
+        ['key4', 'val4a'],
+        ['key4', 'val4b'],
+      ])
+    );
+  });
 });

--- a/test/fetch-http.test.js
+++ b/test/fetch-http.test.js
@@ -99,7 +99,7 @@ describe('fetch: the basics', () => {
       .json()
       .then(echo => {
         assert.equal(
-          '/echo?y=url&z=bar&y=other&a=1&a=2',
+          '/echo?y=other&z=bar&a=1&a=2',
           decodeURIComponent(echo.url)
         );
       });

--- a/test/mock-service.js
+++ b/test/mock-service.js
@@ -6,7 +6,7 @@
 const http = require('http');
 const https = require('https');
 
-const selfSigned = require('self-signed');
+const selfsigned = require('selfsigned');
 
 const options = require('./mock-service.browser');
 
@@ -17,18 +17,9 @@ let server;
 let serverTls;
 
 function generateCertOptions() {
-  const keypair = selfSigned(
-    {
-      name: 'localhost',
-      city: 'Chicago',
-      state: 'Illinois',
-      organization: 'Test',
-      unit: 'Test',
-    },
-    {
-      alt: ['127.0.0.1', 'http://localhost'],
-      expire: 60 * 60 * 1000, // one hour
-    }
+  const keypair = selfsigned.generate(
+    [{ name: 'commonName', value: 'localhost' }],
+    { expire: 60 * 60 * 1000 } // one hour
   );
   return {
     cert: keypair.cert,


### PR DESCRIPTION
```js
const client = new Gofer({ c: { qs: { id: 'x' } } }, 'c');
// both of these now work and request /go?id=x&other=y
await client.get('/go', { qs: { other: 'y' } });
// fixed
await client.get('/go', { qs: new URLSearchParams({ other: 'y' }) });
```

NOTE: values for a given key replace all values for existing key
(don't think this rises to the level of breaking):

```js
const config = { c: { qs: { a: '1', b: '3' } } };
const client = new Gofer(config, 'c');
console.log(client.getMergedOptions(
  {},
  { qs: new URLSearchParams([['a', '2'], ['a', '4']]) }
));

// before:
// new URLSearchParams([['a', '1'], ['b', '3'], ['a', '2'], ['a', '4']])

// now: (note existing a: 1 has been removed)
// new URLSearchParams([['a', '2'], ['b', '3'], ['a', '4']])
```

---
_This PR was started by: [git wf pr](https://github.com/groupon/git-workflow/releases/tag/v1.3.4)_